### PR TITLE
Add minimal Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:22.04
+
+ENV BLENDER_MIRROR=https://mirror.clarkson.edu/blender/release/Blender3.6
+ENV BLENDER_VERSION=3.6.2
+
+# Install and setup blender
+RUN apt-get update && \
+    apt-get install -y \
+       libxrender1 libxkbcommon-x11-0 xvfb libxi6 \
+       wget unzip python3-numpy xz-utils && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /src/blender
+RUN wget ${BLENDER_MIRROR}/blender-${BLENDER_VERSION}-linux-x64.tar.xz && \
+    tar -xf blender-${BLENDER_VERSION}-linux-x64.tar.xz
+ENV PATH="${PATH}:/src/blender/blender-${BLENDER_VERSION}-linux-x64"
+
+# Add our source code
+COPY . /src/TraitBlender
+WORKDIR /src/TraitBlender
+
+# Install the blender TraitBlender addon
+RUN blender --background -E CYCLES --python dockersetup.py
+
+# Setup default command to run a simple example
+CMD blender --background -E CYCLES --python generate_dataset.py -- Examples/Functions/make_snail.py Examples/Data/tiny_snails.csv 'Examples/Raw Datasets/docker_squares/traitblender_settings.json'
+

--- a/Examples/Data/tiny_snails.csv
+++ b/Examples/Data/tiny_snails.csv
@@ -1,0 +1,2 @@
+label,coil_fatness,face_height,degree_of_coiling
+the first snail,0.991420553,0.208535271,15.00687807

--- a/Examples/Raw Datasets/docker_squares/traitblender_settings.json
+++ b/Examples/Raw Datasets/docker_squares/traitblender_settings.json
@@ -1,0 +1,39 @@
+{
+    "World Background Controls": {
+        "wc_colors": [
+            0.0,
+            0.0,
+            0.0,
+            1.0
+        ]
+    },
+    "Background Controls": {
+        "background_plane_image_path": "None",
+        "background_plane_distance": 10.0,
+        "bg_scales": [
+            1.0,
+            1.0,
+            1.0
+        ]
+    },
+    "Lights": {
+        "sun_strength": 1.0
+    },
+    "Camera Controls": {
+        "Cameras to Render": "camera.top,camera.bottom,camera.right,camera.left,camera.front,camera.back",
+        "place_cameras_distance": 10.0,
+        "camera_width_height": [
+            700,
+            700
+        ],
+        "focal_length": 300.0,
+        "render_output_directory": "results/images"
+    },
+    "obj_export_directory": "results/models",
+    "export_format": ".fbx",
+    "Dataset Options": {
+        "use_suns": true,
+        "use_cameras": true,
+        "use_3d_export": false
+    }
+}

--- a/README.md
+++ b/README.md
@@ -24,3 +24,20 @@
 
 ####Rest in progress
 
+
+### Docker
+The following commands need to be run from the base directory of this repo.
+
+#### Build
+```
+docker build -t traitblender .
+```
+
+#### Run
+On Linux or Mac
+```
+mkdir results
+docker run -v $(pwd)/results:/src/TraitBlender/results -it traitblender
+```
+On Windows you will need to replace `$(pwd)` with your current directory.
+When the above command completes check the `results` directory for images created.

--- a/dockersetup.py
+++ b/dockersetup.py
@@ -1,0 +1,2 @@
+import bpy
+bpy.ops.preferences.addon_install(filepath="/src/TraitBlender/TraitBlender.zip")

--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -2,6 +2,7 @@
 import bpy
 import json
 import sys
+bpy.ops.preferences.addon_enable(module="TraitBlender")
 
 # Function to get command-line arguments passed to Blender (skip the first two arguments which are blender related)
 def get_args():


### PR DESCRIPTION
Adds simple Dockerfile that installs blender and installs the TraitBlender addon. The default command runs the code with a really small example dataset.

One known issue is on macOS with M1 and M2 chips there is a bug in qemu that causes blender to fail.
See https://projects.blender.org/blender/blender/issues/92956 and https://gitlab.com/qemu-project/qemu/-/issues/750

Fixes #1