### PR TITLE
v2.4.0

### DIFF
--- a/.github/workflows/release-zips.yml
+++ b/.github/workflows/release-zips.yml
@@ -1,5 +1,5 @@
 # Build extension zips and attach them to a GitHub release when you publish one.
-# How to use: Create a release (draft or direct publish) with a tag (e.g. v2.3.0). When the release
+# How to use: Create a release (draft or direct publish) with a tag (e.g. v2.4.0). When the release
 # is published, this workflow runs, builds Windows/Mac/Linux zips, and uploads them as release assets.
 
 name: Release extension zips

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ PLAN.md
 traitblender/site/
 
 # =============================================================================
-# RELEASE CHECKLIST — TraitBlender version (currently 2.3.0)
-# Search/replace 2.3.0 → X.Y.Z and v2.3.0 → vX.Y.Z unless noted below.
+# RELEASE CHECKLIST — TraitBlender version (currently 2.4.0)
+# Search/replace 2.4.0 → X.Y.Z and v2.4.0 → vX.Y.Z unless noted below.
 # =============================================================================
 
 # --- Addon package (extension build version; keep both in sync) ---

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -45,9 +45,9 @@
     "computer vision"
   ],
   "title": "TraitBlender",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "MIT",
-  "publication_date": "2026-06-11",
+  "publication_date": "2026-07-27",
   "grants": [
     {
       "id": "021nxhr62::2118240"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -47,7 +47,7 @@
   "title": "TraitBlender",
   "version": "2.4.0",
   "license": "MIT",
-  "publication_date": "2026-07-28",
+  "publication_date": "2026-07-29",
   "grants": [
     {
       "id": "021nxhr62::2118240"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -47,7 +47,7 @@
   "title": "TraitBlender",
   "version": "2.4.0",
   "license": "MIT",
-  "publication_date": "2026-07-27",
+  "publication_date": "2026-07-28",
   "grants": [
     {
       "id": "021nxhr62::2118240"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,7 +23,7 @@ authors:
     given-names: Josef
     orcid: "https://orcid.org/0000-0003-4624-9680"
 cff-version: 1.2.0
-date-released: "2026-07-28"
+date-released: "2026-07-29"
 doi: 10.5281/zenodo.14804133
 identifiers:
   - type: url

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,12 +23,12 @@ authors:
     given-names: Josef
     orcid: "https://orcid.org/0000-0003-4624-9680"
 cff-version: 1.2.0
-date-released: "2026-06-11"
+date-released: "2026-07-27"
 doi: 10.5281/zenodo.14804133
 identifiers:
   - type: url
-    description: "The GitHub release URL for version 2.3.0."
-    value: "https://github.com/Imageomics/TraitBlender/releases/tag/v2.3.0"
+    description: "The GitHub release URL for version 2.4.0."
+    value: "https://github.com/Imageomics/TraitBlender/releases/tag/v2.4.0"
 keywords:
   - Imageomics
   - Blender
@@ -40,7 +40,7 @@ license: "MIT"
 message: "If you find this software helpful in your research, please cite this software release."
 repository-code: "https://github.com/Imageomics/TraitBlender"
 title: "TraitBlender"
-version: 2.3.0
+version: 2.4.0
 type: software
 contact:
   - family-names: Charpentier

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,7 +23,7 @@ authors:
     given-names: Josef
     orcid: "https://orcid.org/0000-0003-4624-9680"
 cff-version: 1.2.0
-date-released: "2026-07-27"
+date-released: "2026-07-28"
 doi: 10.5281/zenodo.14804133
 identifiers:
   - type: url

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="traitblender/docs/images/logo.svg" alt="TraitBlender logo" width="360"/>
 </p>
 
-TraitBlender is a Blender add-on for generating museum-style images and 3D meshes of specimens from theoretical morphospaces. **v2.3.0** targets **Blender 5.1+** (Python 3.13 wheels) on Windows, macOS, and Linux.
+TraitBlender is a Blender add-on for generating museum-style images and 3D meshes of specimens from theoretical morphospaces. **v2.4.0** targets **Blender 5.1+** (Python 3.13 wheels) on Windows, macOS, and Linux.
 
 ## Features
 
@@ -32,6 +32,6 @@ For installation, quick start, and full documentation, see the [docs](https://im
 
 You can also install a release zip from the command line:
 
-`blender --command extension install-file -r user_default --enable traitblender-v2.3.0-linux.zip`
+`blender --command extension install-file -r user_default --enable traitblender-v2.4.0-linux.zip`
 
 Use the zip that matches your OS (for example: `...-windows.zip`, `...-mac.zip`, or `...-linux.zip`, `...-linux-headless.zip`).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ TraitBlender is a Blender add-on for generating museum-style images and 3D meshe
 
 **Dataset import, editing, and saving** — Specimen trait values are read from CSV, TSV, or Excel. The built-in dataset editor supports filtering, sorting, pagination, and saving changes back to file, so you can curate and tweak trait tables without leaving Blender.
 
-**Built-in orientations** — Each morphospace defines named orientations (e.g. "Default", "Aperture view") that place specimens consistently on the table. The imaging pipeline can render multiple orientations per specimen so images are comparable across specimens and runs.
+**Built-in and custom orientations** — Each morphospace defines named orientations (e.g. "Default", "Aperture view") that place specimens consistently on the table. You can also add **custom Euler orientations** (name + radians) that run Default, then rotate in the specimen’s local frame, for any morphospace. The imaging pipeline can render multiple orientations per specimen so images are comparable across specimens and runs.
 
 **Stochastic transform pipeline** — Scene properties (e.g. camera location, focal length, lamp power) can be driven by configurable transforms with normal or other samplers. This adds controlled variation to images (e.g. small camera jitter) for robustness or data augmentation while keeping the setup reproducible via the same config and seed.
 

--- a/build_zips/blender_manifest.template.toml
+++ b/build_zips/blender_manifest.template.toml
@@ -3,7 +3,7 @@
 schema_version = "1.0.0"
 
 id = "traitblender"
-version = "2.3.0"
+version = "2.4.0"
 name = "TraitBlender"
 tagline = "Generate museum-style images for morphological datasets"
 maintainer = "Caleb Charpentier <calebcharpentier00@gmail.com>"

--- a/requirements-wheels-headless.txt
+++ b/requirements-wheels-headless.txt
@@ -1,6 +1,6 @@
 # Same as requirements-wheels.txt but without dearpygui (headless / no GUI CSV editor).
 # Regenerate: py -3.13 build_zips/download_wheels.py linux-headless
-vtk==9.4.2
+vtk==9.6.2
 numpy==2.2.6
 scipy==1.16.0
 pandas==2.2.3

--- a/requirements-wheels.txt
+++ b/requirements-wheels.txt
@@ -1,7 +1,8 @@
 # Pin versions with CPython 3.13 wheels (Blender 5.1+). Listed packages only (--no-deps):
 #   py -3.13 build_zips/download_wheels.py windows|mac|linux
-# vtk 9.4+ has cp313 wheels (9.2.x does not).
-vtk==9.4.2
+# vtk 9.4+ has cp313 wheels (9.2.x does not). Prefer 9.6.2+ for Blender 5.1 ABI
+# compatibility on Linux/headless (older wheels can segfault on import vtk).
+vtk==9.6.2
 numpy==2.2.6
 scipy==1.16.0
 pandas==2.2.3

--- a/traitblender/assets/configs/default.yaml
+++ b/traitblender/assets/configs/default.yaml
@@ -46,9 +46,18 @@ mat:
   roughness: 1.0
   scale: [0.15, 0.15, 1.0]
 render:
-  eevee_use_raytracing: false
-  # Eevee id is version-specific (BLENDER_EEVEE_NEXT vs BLENDER_EEVEE); normalized on load.
-  engine: BLENDER_EEVEE_NEXT
+  # Eevee id is version-specific (BLENDER_EEVEE_NEXT vs BLENDER_EEVEE); both accepted in YAML.
+  engine: BLENDER_EEVEE
+  eevee:
+    use_raytracing: false
+    taa_render_samples: 64
+  # When engine is CYCLES, export uses a cycles: block instead, e.g.:
+  # cycles:
+  #   use_adaptive_sampling: true
+  #   adaptive_threshold: 0.01
+  #   samples: 4096
+  #   adaptive_min_samples: 0
+  #   time_limit: 0.0
 output:
   image_format: PNG
   images_per_view: 1

--- a/traitblender/blender_manifest.toml
+++ b/traitblender/blender_manifest.toml
@@ -3,7 +3,7 @@
 schema_version = "1.0.0"
 
 id = "traitblender"
-version = "2.3.0"
+version = "2.4.0"
 name = "TraitBlender"
 tagline = "Generate museum-style images for morphological datasets"
 maintainer = "Caleb Charpentier <calebcharpentier00@gmail.com>"

--- a/traitblender/blender_manifest.toml
+++ b/traitblender/blender_manifest.toml
@@ -31,7 +31,7 @@ wheels = [
   "./wheels/scipy-1.16.0-cp313-cp313-win_amd64.whl",
   "./wheels/six-1.17.0-py2.py3-none-any.whl",
   "./wheels/tzdata-2026.1-py2.py3-none-any.whl",
-  "./wheels/vtk-9.4.2-cp313-cp313-win_amd64.whl",
+  "./wheels/vtk-9.6.2-cp313-cp313-win_amd64.whl",
 ]
 
 
@@ -48,7 +48,7 @@ pytz = "./wheels/pytz-2026.1.post1-py2.py3-none-any.whl"
 scipy = "./wheels/scipy-1.16.0-cp313-cp313-win_amd64.whl"
 six = "./wheels/six-1.17.0-py2.py3-none-any.whl"
 tzdata = "./wheels/tzdata-2026.1-py2.py3-none-any.whl"
-vtk = "./wheels/vtk-9.4.2-cp313-cp313-win_amd64.whl"
+vtk = "./wheels/vtk-9.6.2-cp313-cp313-win_amd64.whl"
 
 
 [permissions]

--- a/traitblender/core/__init__.py
+++ b/traitblender/core/__init__.py
@@ -45,8 +45,8 @@ from .datasets import launch_dataset_viewer_with_string
 # Mesh exports
 from .meshes import export_current_sample
 
-# Config, morphospaces (placeholder for future development)
-# from .morphospaces import *
+# In-addon unit tests
+from .unit_test import TESTS, list_tests, run_test, help_tests, test_config_matches_scene
 
 __all__ = [
     # Helper functions
@@ -77,4 +77,11 @@ __all__ = [
 
     # Meshes
     "export_current_sample",
+
+    # Unit tests
+    "TESTS",
+    "list_tests",
+    "help_tests",
+    "run_test",
+    "test_config_matches_scene",
 ]

--- a/traitblender/core/config/templates/imaging.py
+++ b/traitblender/core/config/templates/imaging.py
@@ -2,6 +2,8 @@
 Imaging pipeline configuration: selected orientations and images per orientation.
 """
 
+from __future__ import annotations
+
 import bpy
 from bpy.props import (
     BoolProperty,
@@ -12,6 +14,12 @@ from bpy.props import (
 )
 
 from .. import config_subsection_register, TraitBlenderConfig
+from ...helpers.orientation_helpers import (
+    _custom_name_update_guard,
+    custom_orientation_name_error,
+    is_valid_custom_orientation_name,
+    unique_custom_orientation_name,
+)
 
 
 class ImagingOrientationItem(bpy.types.PropertyGroup):
@@ -25,13 +33,94 @@ class ImagingOrientationItem(bpy.types.PropertyGroup):
     )
 
 
+def _morphospace_name_from_context(context):
+    try:
+        return context.scene.traitblender_setup.available_morphospaces
+    except Exception:
+        return None
+
+
+def _custom_item_index(imaging, item) -> int | None:
+    ptr = item.as_pointer()
+    for i, other in enumerate(imaging.custom_orientations):
+        if other.as_pointer() == ptr:
+            return i
+    return None
+
+
+def _update_custom_orientation_name(self, context):
+    """Reject invalid / duplicate names; revert to last good name when needed."""
+    ptr = self.as_pointer()
+    if ptr in _custom_name_update_guard:
+        return
+
+    try:
+        imaging = context.scene.traitblender_config.imaging
+    except Exception:
+        return
+
+    morphospace_name = _morphospace_name_from_context(context)
+    idx = _custom_item_index(imaging, self)
+    proposed = (self.name or "").strip()
+    err = custom_orientation_name_error(
+        proposed,
+        imaging,
+        morphospace_name=morphospace_name,
+        exclude_index=idx,
+    )
+
+    last_ok = (self.validated_name or "").strip()
+    if err is None:
+        _custom_name_update_guard.add(ptr)
+        try:
+            if self.name != proposed:
+                self.name = proposed
+            if self.validated_name != proposed:
+                self.validated_name = proposed
+        finally:
+            _custom_name_update_guard.discard(ptr)
+        return
+
+    print(f"TraitBlender: {err}")
+    fallback = last_ok if (
+        last_ok
+        and custom_orientation_name_error(
+            last_ok,
+            imaging,
+            morphospace_name=morphospace_name,
+            exclude_index=idx,
+        )
+        is None
+    ) else unique_custom_orientation_name(
+        imaging,
+        morphospace_name=morphospace_name,
+        exclude_index=idx,
+    )
+    _custom_name_update_guard.add(ptr)
+    try:
+        self.name = fallback
+        self.validated_name = fallback
+    finally:
+        _custom_name_update_guard.discard(ptr)
+
+
 class ImagingCustomOrientationItem(bpy.types.PropertyGroup):
     """User-defined Euler orientation: name + (rx, ry, rz) in radians."""
 
     name: StringProperty(
         name="Name",
-        description="Display name for this custom orientation (must be unique)",
+        description=(
+            "Unique name: letters, digits, underscores, and hyphens only "
+            "(must not match another custom or a built-in orientation)"
+        ),
         default="Custom",
+        update=_update_custom_orientation_name,
+    )
+    validated_name: StringProperty(
+        name="Validated Name",
+        description="Last accepted custom orientation name",
+        default="",
+        options={'HIDDEN', 'SKIP_SAVE'},
     )
     rotation: FloatVectorProperty(
         name="Rotation",
@@ -98,7 +187,7 @@ class ImagingConfig(TraitBlenderConfig):
             lines.append(f"{indent}custom_orientations:")
             for item in customs:
                 name = item.name.strip()
-                key = name if name.replace("_", "").replace("-", "").isalnum() else repr(name)
+                key = name if is_valid_custom_orientation_name(name) else repr(name)
                 rx, ry, rz = float(item.rotation[0]), float(item.rotation[1]), float(item.rotation[2])
                 lines.append(f"{indent}  {key}: [{rx}, {ry}, {rz}]")
 
@@ -147,6 +236,12 @@ class ImagingConfig(TraitBlenderConfig):
             if isinstance(names, list):
                 enabled_from_yaml = {n for n in names if isinstance(n, str)}
 
+        morphospace_name = None
+        try:
+            morphospace_name = bpy.context.scene.traitblender_setup.available_morphospaces
+        except Exception:
+            pass
+
         if "custom_orientations" in data_dict:
             customs = data_dict["custom_orientations"]
             if isinstance(customs, dict):
@@ -160,8 +255,19 @@ class ImagingConfig(TraitBlenderConfig):
                             f"(expected [rx, ry, rz])."
                         )
                         continue
+                    cleaned = name.strip()
+                    err = custom_orientation_name_error(
+                        cleaned,
+                        self,
+                        morphospace_name=morphospace_name,
+                    )
+                    if err is not None:
+                        print(f"TraitBlender: Skipping custom orientation '{cleaned}': {err}")
+                        continue
                     item = self.custom_orientations.add()
-                    item.name = name.strip()
+                    # Set validated_name first so update accepts the name
+                    item.validated_name = cleaned
+                    item.name = cleaned
                     item.rotation = (float(rot[0]), float(rot[1]), float(rot[2]))
             elif customs is not None:
                 print(
@@ -172,8 +278,6 @@ class ImagingConfig(TraitBlenderConfig):
         # Sync checkboxes now if possible (morphospace may still load later in YAML;
         # configure_scene also syncs after the full from_dict).
         try:
-            import bpy
-
             self.sync_orientation_options(bpy.context, enabled_names=enabled_from_yaml)
         except Exception as e:
             print(f"TraitBlender: Could not sync imaging orientation_options: {e}")

--- a/traitblender/core/config/templates/imaging.py
+++ b/traitblender/core/config/templates/imaging.py
@@ -21,7 +21,7 @@ class ImagingOrientationItem(bpy.types.PropertyGroup):
     enabled: BoolProperty(
         name="Include",
         description="Include this orientation in the imaging pipeline",
-        default=True,
+        default=False,
     )
 
 
@@ -104,6 +104,34 @@ class ImagingConfig(TraitBlenderConfig):
 
         return "\n".join(lines)
 
+    def sync_orientation_options(self, context, enabled_names=None):
+        """
+        Rebuild orientation_options from the live morphospace + customs dict.
+
+        Args:
+            context: Blender context.
+            enabled_names: Optional set/list of names that should be enabled.
+                If None, preserve previous enabled flags; new names default to
+                enabled only when the name is ``Default``.
+        """
+        from ...morphospaces import get_orientation_names
+
+        morphospace_name = context.scene.traitblender_setup.available_morphospaces
+        all_names = (
+            get_orientation_names(morphospace_name, context) if morphospace_name else []
+        )
+        prev_enabled = {item.name: bool(item.enabled) for item in self.orientation_options}
+        enabled_set = set(enabled_names) if enabled_names is not None else None
+
+        self.orientation_options.clear()
+        for name in all_names:
+            item = self.orientation_options.add()
+            item.name = name
+            if enabled_set is not None:
+                item.enabled = name in enabled_set
+            else:
+                item.enabled = prev_enabled.get(name, name == "Default")
+
     def from_dict(self, data_dict):
         """Load imaging section; restore orientation_options and custom_orientations."""
         if not isinstance(data_dict, dict):
@@ -113,10 +141,16 @@ class ImagingConfig(TraitBlenderConfig):
         if "images_per_orientation" in data_dict:
             self.images_per_orientation = data_dict["images_per_orientation"]
 
+        enabled_from_yaml = {"Default"}
+        if "orientation_names" in data_dict:
+            names = data_dict["orientation_names"]
+            if isinstance(names, list):
+                enabled_from_yaml = {n for n in names if isinstance(n, str)}
+
         if "custom_orientations" in data_dict:
             customs = data_dict["custom_orientations"]
-            self.custom_orientations.clear()
             if isinstance(customs, dict):
+                self.custom_orientations.clear()
                 for name, rot in customs.items():
                     if not isinstance(name, str) or not name.strip():
                         continue
@@ -129,13 +163,23 @@ class ImagingConfig(TraitBlenderConfig):
                     item = self.custom_orientations.add()
                     item.name = name.strip()
                     item.rotation = (float(rot[0]), float(rot[1]), float(rot[2]))
+            elif customs is not None:
+                print(
+                    "TraitBlender: custom_orientations must be a mapping of "
+                    "name → [rx, ry, rz]; leaving existing customs unchanged."
+                )
 
-        if "orientation_names" in data_dict:
-            names = data_dict["orientation_names"]
-            if isinstance(names, list):
+        # Sync checkboxes now if possible (morphospace may still load later in YAML;
+        # configure_scene also syncs after the full from_dict).
+        try:
+            import bpy
+
+            self.sync_orientation_options(bpy.context, enabled_names=enabled_from_yaml)
+        except Exception as e:
+            print(f"TraitBlender: Could not sync imaging orientation_options: {e}")
+            if enabled_from_yaml is not None:
                 self.orientation_options.clear()
-                for n in names:
-                    if isinstance(n, str):
-                        item = self.orientation_options.add()
-                        item.name = n
-                        item.enabled = True
+                for n in enabled_from_yaml:
+                    item = self.orientation_options.add()
+                    item.name = n
+                    item.enabled = True

--- a/traitblender/core/config/templates/imaging.py
+++ b/traitblender/core/config/templates/imaging.py
@@ -3,7 +3,13 @@ Imaging pipeline configuration: selected orientations and images per orientation
 """
 
 import bpy
-from bpy.props import BoolProperty, CollectionProperty, IntProperty, StringProperty
+from bpy.props import (
+    BoolProperty,
+    CollectionProperty,
+    FloatVectorProperty,
+    IntProperty,
+    StringProperty,
+)
 
 from .. import config_subsection_register, TraitBlenderConfig
 
@@ -12,11 +18,35 @@ class ImagingOrientationItem(bpy.types.PropertyGroup):
     """One orientation option for the imaging pipeline (name + enabled checkbox)."""
 
     name: StringProperty(name="Orientation", default="")
-    enabled: BoolProperty(name="Include", description="Include this orientation in the imaging pipeline", default=True)
+    enabled: BoolProperty(
+        name="Include",
+        description="Include this orientation in the imaging pipeline",
+        default=True,
+    )
 
 
-# Register so ImagingConfig can use CollectionProperty(type=ImagingOrientationItem)
+class ImagingCustomOrientationItem(bpy.types.PropertyGroup):
+    """User-defined Euler orientation: name + (rx, ry, rz) in radians."""
+
+    name: StringProperty(
+        name="Name",
+        description="Display name for this custom orientation (must be unique)",
+        default="Custom",
+    )
+    rotation: FloatVectorProperty(
+        name="Rotation",
+        description=(
+            "Local Euler rotation in radians (X, Y, Z) applied after Default, "
+            "relative to the specimen's axes before bake"
+        ),
+        size=3,
+        default=(0.0, 0.0, 0.0),
+    )
+
+
+# Register so ImagingConfig can use CollectionProperty types
 bpy.utils.register_class(ImagingOrientationItem)
+bpy.utils.register_class(ImagingCustomOrientationItem)
 
 
 @config_subsection_register("imaging")
@@ -36,6 +66,13 @@ class ImagingConfig(TraitBlenderConfig):
         name="Orientations",
         description="Orientations from the selected morphospace; checked = include in pipeline",
     )
+    custom_orientations: CollectionProperty(
+        type=ImagingCustomOrientationItem,
+        name="Custom Orientations",
+        description=(
+            "Named local Euler orientations (radians) applied after Default for all morphospaces"
+        ),
+    )
     images_per_orientation: IntProperty(
         name="Images Per Orientation",
         description="Number of images to render per orientation (transforms applied each time)",
@@ -53,16 +90,46 @@ class ImagingConfig(TraitBlenderConfig):
             f'{indent}orientation_names: [{", ".join(safe)}]',
             f"{indent}images_per_orientation: {self.images_per_orientation}",
         ]
+
+        customs = [
+            item for item in self.custom_orientations if (item.name or "").strip()
+        ]
+        if customs:
+            lines.append(f"{indent}custom_orientations:")
+            for item in customs:
+                name = item.name.strip()
+                key = name if name.replace("_", "").replace("-", "").isalnum() else repr(name)
+                rx, ry, rz = float(item.rotation[0]), float(item.rotation[1]), float(item.rotation[2])
+                lines.append(f"{indent}  {key}: [{rx}, {ry}, {rz}]")
+
         return "\n".join(lines)
 
     def from_dict(self, data_dict):
-        """Load imaging section; restore orientation_options from orientation_names list."""
+        """Load imaging section; restore orientation_options and custom_orientations."""
         if not isinstance(data_dict, dict):
             raise ValueError("Input must be a dictionary")
         if "include_images" in data_dict:
             self.include_images = bool(data_dict["include_images"])
         if "images_per_orientation" in data_dict:
             self.images_per_orientation = data_dict["images_per_orientation"]
+
+        if "custom_orientations" in data_dict:
+            customs = data_dict["custom_orientations"]
+            self.custom_orientations.clear()
+            if isinstance(customs, dict):
+                for name, rot in customs.items():
+                    if not isinstance(name, str) or not name.strip():
+                        continue
+                    if not isinstance(rot, (list, tuple)) or len(rot) < 3:
+                        print(
+                            f"TraitBlender: Skipping custom orientation '{name}' "
+                            f"(expected [rx, ry, rz])."
+                        )
+                        continue
+                    item = self.custom_orientations.add()
+                    item.name = name.strip()
+                    item.rotation = (float(rot[0]), float(rot[1]), float(rot[2]))
+
         if "orientation_names" in data_dict:
             names = data_dict["orientation_names"]
             if isinstance(names, list):

--- a/traitblender/core/config/templates/meshes.py
+++ b/traitblender/core/config/templates/meshes.py
@@ -25,7 +25,19 @@ class MeshesConfig(TraitBlenderConfig):
 
     save_meshes: BoolProperty(
         name="Save Meshes",
-        description="If enabled, export a 3D model for each specimen during the imaging pipeline (Default orientation only)",
+        description=(
+            "If enabled, export a 3D model for each specimen during the imaging pipeline"
+        ),
         default=False,
+    )
+
+    orient_before_export: BoolProperty(
+        name="Orient Before Export",
+        description=(
+            "If enabled (default), apply the morphospace Default orientation before exporting "
+            "meshes (table placement). Disable to export the generated mesh as-is—useful for "
+            "ATLAS, where the SSM already provides a consistent PCA-aligned frame"
+        ),
+        default=True,
     )
 

--- a/traitblender/core/config/templates/morphospace.py
+++ b/traitblender/core/config/templates/morphospace.py
@@ -101,7 +101,17 @@ class MorphospaceConfig(TraitBlenderConfig):
         if not data_dict or not isinstance(data_dict, dict):
             return
         if "name" in data_dict:
-            self.name = data_dict["name"]
+            import bpy
+
+            setup = bpy.context.scene.traitblender_setup
+            # Avoid morphospace-switch confirm popup mid Configure Scene (it reverts the enum).
+            setup.suppress_morphospace_update = True
+            try:
+                self.name = data_dict["name"]
+                setup.prev_morphospace = setup.available_morphospaces
+                setup.pending_morphospace = ""
+            finally:
+                setup.suppress_morphospace_update = False
         hyperparams = data_dict.get("hyperparams")
         if isinstance(hyperparams, dict):
             module_keys = get_hyperparameters_for_morphospace(self.name).keys()

--- a/traitblender/core/config/templates/render.py
+++ b/traitblender/core/config/templates/render.py
@@ -1,4 +1,35 @@
+"""
+Render configuration: engine plus Cycles/Eevee sampling settings.
+
+YAML shape (engine-specific blocks are optional; only the active engine's block
+is written on export, but both are accepted on load):
+
+  render:
+    engine: CYCLES
+    cycles:
+      use_adaptive_sampling: true
+      adaptive_threshold: 0.01
+      samples: 32
+      adaptive_min_samples: 0
+      time_limit: 0.0
+      use_denoising: true
+      use_preview_adaptive_sampling: true
+      preview_adaptive_threshold: 0.1
+      preview_samples: 1024
+      preview_adaptive_min_samples: 0
+      use_preview_denoising: false
+    eevee:
+      use_raytracing: false
+      taa_render_samples: 64
+
+Legacy flat ``eevee_use_raytracing`` is still accepted on load.
+"""
+
+from __future__ import annotations
+
 import bpy
+from bpy.props import BoolProperty, FloatProperty, IntProperty, PointerProperty
+
 from .. import config_subsection_register, TraitBlenderConfig
 from ...helpers import get_property, set_property
 from ...helpers.render_engine_compat import (
@@ -9,14 +40,32 @@ from ...helpers.render_engine_compat import (
     try_set_render_engine,
 )
 
+# Keys written to / read from scene.cycles (final render + viewport).
+CYCLES_SCENE_KEYS = (
+    "use_adaptive_sampling",
+    "adaptive_threshold",
+    "samples",
+    "adaptive_min_samples",
+    "time_limit",
+    "use_denoising",
+    "use_preview_adaptive_sampling",
+    "preview_adaptive_threshold",
+    "preview_samples",
+    "preview_adaptive_min_samples",
+    "use_preview_denoising",
+)
+
+EEVEE_SCENE_KEYS = (
+    "use_raytracing",
+    "taa_render_samples",
+)
+
 
 def _render_engine_items(self, context):
-    """Live enum items so Eevee id matches this Blender build."""
     return render_engine_enum_items()
 
 
 def _get_render_engine(self):
-    # EnumProperty get/set use item *numbers*, not list indices.
     try:
         return render_engine_number_for_identifier(bpy.context.scene.render.engine)
     except Exception:
@@ -34,33 +83,155 @@ def _set_render_engine(self, value):
         print(f"TraitBlender: Failed to set render.engine to '{value}': {e}")
 
 
+def _is_eevee_engine(engine: str) -> bool:
+    return "EEVEE" in (engine or "").upper()
+
+
+def _is_cycles_engine(engine: str) -> bool:
+    return (engine or "").upper() == "CYCLES"
+
+
+def _apply_mapping_to_id(target, data: dict, allowed_keys: tuple) -> list[str]:
+    """
+    Apply YAML dict keys onto a Blender ID/RNA struct (scene.cycles / scene.eevee).
+
+    Returns list of error strings (empty if all ok).
+    """
+    errors = []
+    if target is None:
+        return ["target RNA is None"]
+    for key, value in data.items():
+        if key not in allowed_keys:
+            continue
+        if not hasattr(target, key):
+            errors.append(f"missing attribute {key!r}")
+            continue
+        try:
+            setattr(target, key, value)
+        except Exception as e:
+            errors.append(f"{key}={value!r}: {e}")
+    return errors
+
+
+def _snapshot_mapping(target, allowed_keys: tuple) -> dict:
+    """Read allowed keys from a Blender RNA struct into a plain dict."""
+    out = {}
+    if target is None:
+        return out
+    for key in allowed_keys:
+        if hasattr(target, key):
+            try:
+                out[key] = getattr(target, key)
+            except Exception:
+                pass
+    return out
+
+
+class CyclesRenderConfig(TraitBlenderConfig):
+    """Cycles sampling (mirrors ``scene.cycles`` for UI / export helpers)."""
+
+    use_adaptive_sampling: BoolProperty(
+        name="Noise Threshold",
+        default=True,
+        get=get_property("bpy.context.scene.cycles.use_adaptive_sampling"),
+        set=set_property("bpy.context.scene.cycles.use_adaptive_sampling"),
+    )
+    adaptive_threshold: FloatProperty(
+        name="Adaptive Threshold",
+        default=0.01,
+        min=0.0,
+        max=1.0,
+        get=get_property("bpy.context.scene.cycles.adaptive_threshold"),
+        set=set_property("bpy.context.scene.cycles.adaptive_threshold"),
+    )
+    samples: IntProperty(
+        name="Max Samples",
+        default=4096,
+        min=1,
+        get=get_property("bpy.context.scene.cycles.samples"),
+        set=set_property("bpy.context.scene.cycles.samples"),
+    )
+    adaptive_min_samples: IntProperty(
+        name="Min Samples",
+        default=0,
+        min=0,
+        get=get_property("bpy.context.scene.cycles.adaptive_min_samples"),
+        set=set_property("bpy.context.scene.cycles.adaptive_min_samples"),
+    )
+    time_limit: FloatProperty(
+        name="Time Limit",
+        default=0.0,
+        min=0.0,
+        get=get_property("bpy.context.scene.cycles.time_limit"),
+        set=set_property("bpy.context.scene.cycles.time_limit"),
+    )
+    use_denoising: BoolProperty(
+        name="Denoise",
+        default=False,
+        get=get_property("bpy.context.scene.cycles.use_denoising"),
+        set=set_property("bpy.context.scene.cycles.use_denoising"),
+    )
+    use_preview_adaptive_sampling: BoolProperty(
+        name="Viewport Noise Threshold",
+        default=True,
+        get=get_property("bpy.context.scene.cycles.use_preview_adaptive_sampling"),
+        set=set_property("bpy.context.scene.cycles.use_preview_adaptive_sampling"),
+    )
+    preview_adaptive_threshold: FloatProperty(
+        name="Viewport Adaptive Threshold",
+        default=0.1,
+        min=0.0,
+        max=1.0,
+        get=get_property("bpy.context.scene.cycles.preview_adaptive_threshold"),
+        set=set_property("bpy.context.scene.cycles.preview_adaptive_threshold"),
+    )
+    preview_samples: IntProperty(
+        name="Viewport Max Samples",
+        default=1024,
+        min=1,
+        get=get_property("bpy.context.scene.cycles.preview_samples"),
+        set=set_property("bpy.context.scene.cycles.preview_samples"),
+    )
+    preview_adaptive_min_samples: IntProperty(
+        name="Viewport Min Samples",
+        default=0,
+        min=0,
+        get=get_property("bpy.context.scene.cycles.preview_adaptive_min_samples"),
+        set=set_property("bpy.context.scene.cycles.preview_adaptive_min_samples"),
+    )
+    use_preview_denoising: BoolProperty(
+        name="Viewport Denoise",
+        default=False,
+        get=get_property("bpy.context.scene.cycles.use_preview_denoising"),
+        set=set_property("bpy.context.scene.cycles.use_preview_denoising"),
+    )
+
+
+class EeveeRenderConfig(TraitBlenderConfig):
+    """Eevee settings (mirrors ``scene.eevee``)."""
+
+    use_raytracing: BoolProperty(
+        name="Use Raytracing",
+        default=False,
+        get=get_property("bpy.context.scene.eevee.use_raytracing"),
+        set=set_property("bpy.context.scene.eevee.use_raytracing"),
+    )
+    taa_render_samples: IntProperty(
+        name="Samples",
+        default=64,
+        min=1,
+        get=get_property("bpy.context.scene.eevee.taa_render_samples"),
+        set=set_property("bpy.context.scene.eevee.taa_render_samples"),
+    )
+
+
+bpy.utils.register_class(CyclesRenderConfig)
+bpy.utils.register_class(EeveeRenderConfig)
+
+
 @config_subsection_register("render")
 class RenderConfig(TraitBlenderConfig):
     print_index = 5
-
-    def from_dict(self, data_dict):
-        if not isinstance(data_dict, dict):
-            return
-        data = dict(data_dict)
-        if "engine" in data:
-            # Apply directly — do not gate on RNA enum_items (incomplete on Blender 5.1).
-            raw = data.pop("engine")
-            engine = normalize_render_engine_value(raw)
-            scene = bpy.context.scene
-            try:
-                actual = try_set_render_engine(scene, raw)
-                print(
-                    f"TraitBlender: render.engine from config "
-                    f"raw={raw!r} normalized={engine!r} actual={actual!r}"
-                )
-                if actual != engine:
-                    print(
-                        "TraitBlender: WARNING scene.render.engine did not stick "
-                        f"(wanted {engine!r}, got {actual!r})"
-                    )
-            except Exception as e:
-                print(f"TraitBlender: Failed to apply render.engine '{engine}': {e}")
-        super().from_dict(data)
 
     engine: bpy.props.EnumProperty(
         name="Engine",
@@ -70,10 +241,96 @@ class RenderConfig(TraitBlenderConfig):
         set=_set_render_engine,
     )
 
-    eevee_use_raytracing: bpy.props.BoolProperty(
-        name="Use Raytracing",
-        description="Whether to use raytracing",
+    cycles: PointerProperty(type=CyclesRenderConfig, name="Cycles")
+    eevee: PointerProperty(type=EeveeRenderConfig, name="Eevee")
+
+    eevee_use_raytracing: BoolProperty(
+        name="Use Raytracing (legacy)",
+        description="Deprecated: use render.eevee.use_raytracing",
         default=False,
         get=get_property("bpy.context.scene.eevee.use_raytracing"),
         set=set_property("bpy.context.scene.eevee.use_raytracing"),
+        options={'HIDDEN'},
     )
+
+    def _to_yaml(self, indent_level=0, parent_path=""):
+        """Export engine + only the active engine's settings from live scene RNA."""
+        indent = "  " * indent_level
+        child = "  " * (indent_level + 1)
+        scene = bpy.context.scene
+        engine = normalize_render_engine_value(scene.render.engine)
+        lines = [f"{indent}engine: {engine}"]
+
+        if _is_cycles_engine(engine):
+            snap = _snapshot_mapping(getattr(scene, "cycles", None), CYCLES_SCENE_KEYS)
+            lines.append(f"{indent}cycles:")
+            for key in CYCLES_SCENE_KEYS:
+                if key not in snap:
+                    continue
+                val = snap[key]
+                if isinstance(val, bool):
+                    lines.append(f"{child}{key}: {str(val).lower()}")
+                else:
+                    lines.append(f"{child}{key}: {val}")
+        elif _is_eevee_engine(engine):
+            snap = _snapshot_mapping(getattr(scene, "eevee", None), EEVEE_SCENE_KEYS)
+            lines.append(f"{indent}eevee:")
+            for key in EEVEE_SCENE_KEYS:
+                if key not in snap:
+                    continue
+                val = snap[key]
+                if isinstance(val, bool):
+                    lines.append(f"{child}{key}: {str(val).lower()}")
+                else:
+                    lines.append(f"{child}{key}: {val}")
+
+        return "\n".join(lines)
+
+    def from_dict(self, data_dict):
+        if not isinstance(data_dict, dict):
+            return
+        data = dict(data_dict)
+        scene = bpy.context.scene
+
+        if "engine" in data:
+            raw = data.pop("engine")
+            engine = normalize_render_engine_value(raw)
+            try:
+                actual = try_set_render_engine(scene, raw)
+                print(
+                    f"TraitBlender: render.engine from config "
+                    f"raw={raw!r} normalized={engine!r} actual={actual!r}"
+                )
+            except Exception as e:
+                print(f"TraitBlender: Failed to apply render.engine '{engine}': {e}")
+
+        cycles_data = data.pop("cycles", None)
+        eevee_data = data.pop("eevee", None)
+
+        if "eevee_use_raytracing" in data:
+            legacy = data.pop("eevee_use_raytracing")
+            if not isinstance(eevee_data, dict):
+                eevee_data = {}
+            eevee_data.setdefault("use_raytracing", legacy)
+
+        # Write straight to scene RNA — nested PropertyGroup setters are unreliable here.
+        if isinstance(cycles_data, dict):
+            errs = _apply_mapping_to_id(
+                getattr(scene, "cycles", None), cycles_data, CYCLES_SCENE_KEYS
+            )
+            for err in errs:
+                print(f"TraitBlender: cycles config apply: {err}")
+            applied = _snapshot_mapping(getattr(scene, "cycles", None), CYCLES_SCENE_KEYS)
+            print(f"TraitBlender: cycles applied -> {applied}")
+
+        if isinstance(eevee_data, dict):
+            errs = _apply_mapping_to_id(
+                getattr(scene, "eevee", None), eevee_data, EEVEE_SCENE_KEYS
+            )
+            for err in errs:
+                print(f"TraitBlender: eevee config apply: {err}")
+            applied = _snapshot_mapping(getattr(scene, "eevee", None), EEVEE_SCENE_KEYS)
+            print(f"TraitBlender: eevee applied -> {applied}")
+
+        if data:
+            super().from_dict(data)

--- a/traitblender/core/config/templates/render.py
+++ b/traitblender/core/config/templates/render.py
@@ -1,11 +1,37 @@
 import bpy
 from .. import config_subsection_register, TraitBlenderConfig
 from ...helpers import get_property, set_property
-from ...helpers.render_engine_compat import render_engine_enum_items, render_engine_options
+from ...helpers.render_engine_compat import (
+    normalize_render_engine_value,
+    render_engine_enum_items,
+    render_engine_identifier_for_number,
+    render_engine_number_for_identifier,
+    try_set_render_engine,
+)
 
 
-_RENDER_ENGINE_OPTS = render_engine_options()
-_RENDER_ENGINE_ITEMS = tuple(render_engine_enum_items())
+def _render_engine_items(self, context):
+    """Live enum items so Eevee id matches this Blender build."""
+    return render_engine_enum_items()
+
+
+def _get_render_engine(self):
+    # EnumProperty get/set use item *numbers*, not list indices.
+    try:
+        return render_engine_number_for_identifier(bpy.context.scene.render.engine)
+    except Exception:
+        return 0
+
+
+def _set_render_engine(self, value):
+    try:
+        if isinstance(value, int):
+            engine = render_engine_identifier_for_number(value)
+        else:
+            engine = normalize_render_engine_value(value)
+        bpy.context.scene.render.engine = engine
+    except Exception as e:
+        print(f"TraitBlender: Failed to set render.engine to '{value}': {e}")
 
 
 @config_subsection_register("render")
@@ -15,25 +41,33 @@ class RenderConfig(TraitBlenderConfig):
     def from_dict(self, data_dict):
         if not isinstance(data_dict, dict):
             return
-        from ...helpers.render_engine_compat import normalize_render_engine_value
-
         data = dict(data_dict)
         if "engine" in data:
-            data["engine"] = normalize_render_engine_value(data["engine"])
+            # Apply directly — do not gate on RNA enum_items (incomplete on Blender 5.1).
+            raw = data.pop("engine")
+            engine = normalize_render_engine_value(raw)
+            scene = bpy.context.scene
+            try:
+                actual = try_set_render_engine(scene, raw)
+                print(
+                    f"TraitBlender: render.engine from config "
+                    f"raw={raw!r} normalized={engine!r} actual={actual!r}"
+                )
+                if actual != engine:
+                    print(
+                        "TraitBlender: WARNING scene.render.engine did not stick "
+                        f"(wanted {engine!r}, got {actual!r})"
+                    )
+            except Exception as e:
+                print(f"TraitBlender: Failed to apply render.engine '{engine}': {e}")
         super().from_dict(data)
 
     engine: bpy.props.EnumProperty(
         name="Engine",
         description="The engine to use",
-        items=_RENDER_ENGINE_ITEMS,
-        get=get_property(
-            "bpy.context.scene.render.engine",
-            options=_RENDER_ENGINE_OPTS,
-        ),
-        set=set_property(
-            "bpy.context.scene.render.engine",
-            options=_RENDER_ENGINE_OPTS,
-        ),
+        items=_render_engine_items,
+        get=_get_render_engine,
+        set=_set_render_engine,
     )
 
     eevee_use_raytracing: bpy.props.BoolProperty(
@@ -41,6 +75,5 @@ class RenderConfig(TraitBlenderConfig):
         description="Whether to use raytracing",
         default=False,
         get=get_property("bpy.context.scene.eevee.use_raytracing"),
-        set=set_property("bpy.context.scene.eevee.use_raytracing")
+        set=set_property("bpy.context.scene.eevee.use_raytracing"),
     )
-

--- a/traitblender/core/config/templates/sample.py
+++ b/traitblender/core/config/templates/sample.py
@@ -47,3 +47,7 @@ class SampleConfig(TraitBlenderConfig):
     def _to_yaml(self, indent_level=0, parent_path=""):
         """Override to prevent this configuration from appearing in YAML output."""
         return ""
+
+    def from_dict(self, data_dict):
+        """UI-only section — ignore YAML (including bare ``sample:`` / null / {})."""
+        return

--- a/traitblender/core/config/traitblender_config.py
+++ b/traitblender/core/config/traitblender_config.py
@@ -109,17 +109,24 @@ class TraitBlenderConfig(bpy.types.PropertyGroup):
         for prop_name, value in data_dict.items():
             if prop_name not in annotations:
                 continue
+            # Bare YAML keys like `sample:` become None — never assign onto PointerProperties.
+            if value is None:
+                continue
+
             current_prop = getattr(self, prop_name, None)
             # Duck-type nested sections: isinstance(PropertyGroup, TraitBlenderConfig)
             # can fail across Blender register/reload boundaries.
             from_dict_fn = getattr(current_prop, "from_dict", None)
-            if callable(from_dict_fn) and isinstance(value, (dict, list)):
-                from_dict_fn(value)
-            else:
-                try:
-                    setattr(self, prop_name, value)
-                except Exception as e:
-                    print(f"TraitBlender: Failed to set config '{prop_name}': {e}")
+            if callable(from_dict_fn):
+                if isinstance(value, (dict, list)):
+                    from_dict_fn(value)
+                # Nested section with a non-mapping value: ignore
+                continue
+
+            try:
+                setattr(self, prop_name, value)
+            except Exception as e:
+                print(f"TraitBlender: Failed to set config '{prop_name}': {e}")
 
     def to_dict(self):
         """Convert the configuration to a dictionary."""

--- a/traitblender/core/config/traitblender_config.py
+++ b/traitblender/core/config/traitblender_config.py
@@ -50,11 +50,13 @@ class TraitBlenderConfig(bpy.types.PropertyGroup):
                     continue
 
                 if isinstance(prop_value, TraitBlenderConfig):
-                    result.append(f"{indent}{prop_name}:")
                     current_path = f"{parent_path}.{prop_name}" if parent_path else prop_name
                     nested_yaml = prop_value._to_yaml(indent_level + 1, current_path)
-                    if nested_yaml.strip():
-                        result.append(nested_yaml)
+                    # Skip empty sections (e.g. sample is UI-only and returns "")
+                    if not nested_yaml.strip():
+                        continue
+                    result.append(f"{indent}{prop_name}:")
+                    result.append(nested_yaml)
                 else:
                     current_path = f"{parent_path}.{prop_name}" if parent_path else prop_name
                     prop_type = get_property_type(current_path)
@@ -103,17 +105,21 @@ class TraitBlenderConfig(bpy.types.PropertyGroup):
         if not isinstance(data_dict, dict):
             raise ValueError("Input must be a dictionary")
 
+        annotations = getattr(self.__class__, "__annotations__", {}) or {}
         for prop_name, value in data_dict.items():
-            if prop_name not in self.__class__.__annotations__:
+            if prop_name not in annotations:
                 continue
-            current_prop = getattr(self, prop_name)
-            if isinstance(current_prop, TraitBlenderConfig) and isinstance(value, (dict, list)):
-                current_prop.from_dict(value)
+            current_prop = getattr(self, prop_name, None)
+            # Duck-type nested sections: isinstance(PropertyGroup, TraitBlenderConfig)
+            # can fail across Blender register/reload boundaries.
+            from_dict_fn = getattr(current_prop, "from_dict", None)
+            if callable(from_dict_fn) and isinstance(value, (dict, list)):
+                from_dict_fn(value)
             else:
                 try:
                     setattr(self, prop_name, value)
-                except Exception:
-                    pass
+                except Exception as e:
+                    print(f"TraitBlender: Failed to set config '{prop_name}': {e}")
 
     def to_dict(self):
         """Convert the configuration to a dictionary."""

--- a/traitblender/core/helpers/__init__.py
+++ b/traitblender/core/helpers/__init__.py
@@ -35,7 +35,13 @@ from .transform_sampler_helper import (
     format_parameter_value,
 )
 from .clear_scene import clear_scene
-from .orientation_helpers import bake_rotation_to_mesh, make_euler_orientation
+from .orientation_helpers import (
+    bake_rotation_to_mesh,
+    make_euler_orientation,
+    is_valid_custom_orientation_name,
+    custom_orientation_name_error,
+    unique_custom_orientation_name,
+)
 # Import table location functions
 try:
     from ..ui.properties.tb_location import _get_tb_location, _set_tb_location
@@ -88,6 +94,9 @@ __all__ = [
     # Orientation
     "bake_rotation_to_mesh",
     "make_euler_orientation",
+    "is_valid_custom_orientation_name",
+    "custom_orientation_name_error",
+    "unique_custom_orientation_name",
     # Table location functions
     "z_dist_to_lowest",
     "_get_tb_location",

--- a/traitblender/core/helpers/__init__.py
+++ b/traitblender/core/helpers/__init__.py
@@ -35,7 +35,7 @@ from .transform_sampler_helper import (
     format_parameter_value,
 )
 from .clear_scene import clear_scene
-from .orientation_helpers import bake_rotation_to_mesh
+from .orientation_helpers import bake_rotation_to_mesh, make_euler_orientation
 # Import table location functions
 try:
     from ..ui.properties.tb_location import _get_tb_location, _set_tb_location
@@ -87,6 +87,7 @@ __all__ = [
     "clear_scene",
     # Orientation
     "bake_rotation_to_mesh",
+    "make_euler_orientation",
     # Table location functions
     "z_dist_to_lowest",
     "_get_tb_location",

--- a/traitblender/core/helpers/orientation_helpers.py
+++ b/traitblender/core/helpers/orientation_helpers.py
@@ -2,8 +2,79 @@
 Orientation helpers: bake rotation into mesh, and build custom Euler orientations.
 """
 
+from __future__ import annotations
+
+import re
+
 import bpy
 from mathutils import Euler
+
+# Custom orientation names: YAML-safe identifiers (see docs).
+CUSTOM_ORIENTATION_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+_custom_name_update_guard: set[int] = set()
+
+
+def is_valid_custom_orientation_name(name: str) -> bool:
+    """True if name is non-empty and uses only letters, digits, underscores, hyphens."""
+    return bool(name) and CUSTOM_ORIENTATION_NAME_RE.fullmatch(name) is not None
+
+
+def custom_orientation_name_error(
+    name: str,
+    imaging,
+    *,
+    morphospace_name: str | None = None,
+    exclude_index: int | None = None,
+) -> str | None:
+    """
+    Return a user-facing error if ``name`` is invalid or conflicts; else None.
+
+    Conflicts include other custom orientations and built-ins for ``morphospace_name``.
+    """
+    cleaned = (name or "").strip()
+    if not cleaned:
+        return "Custom orientation name cannot be empty"
+    if not is_valid_custom_orientation_name(cleaned):
+        return (
+            "Custom orientation names may only use letters, digits, "
+            "underscores, and hyphens (no spaces or special characters)"
+        )
+    for i, item in enumerate(getattr(imaging, "custom_orientations", []) or []):
+        if exclude_index is not None and i == exclude_index:
+            continue
+        if (getattr(item, "name", "") or "").strip() == cleaned:
+            return f"Custom orientation name '{cleaned}' is already used"
+    if morphospace_name:
+        from ..morphospaces.get_orientations import get_builtin_orientation_names
+
+        builtins = set(get_builtin_orientation_names(morphospace_name) or [])
+        if cleaned in builtins:
+            return f"'{cleaned}' is already a built-in orientation name"
+    return None
+
+
+def unique_custom_orientation_name(
+    imaging,
+    base: str = "Custom",
+    morphospace_name: str | None = None,
+    exclude_index: int | None = None,
+) -> str:
+    """Allocate a valid custom name that does not collide with customs or built-ins."""
+    base = base if is_valid_custom_orientation_name(base) else "Custom"
+    candidate = base
+    n = 0
+    while custom_orientation_name_error(
+        candidate,
+        imaging,
+        morphospace_name=morphospace_name,
+        exclude_index=exclude_index,
+    ):
+        n += 1
+        candidate = f"{base}_{n}"
+        if n > 10000:
+            return f"Custom_{n}"
+    return candidate
 
 
 def bake_rotation_to_mesh(object_name):

--- a/traitblender/core/helpers/orientation_helpers.py
+++ b/traitblender/core/helpers/orientation_helpers.py
@@ -1,9 +1,9 @@
 """
-Bake object rotation into mesh so rotation becomes (0,0,0).
-Used at the end of each orientation so transforms work from an applied state.
+Orientation helpers: bake rotation into mesh, and build custom Euler orientations.
 """
 
 import bpy
+from mathutils import Euler
 
 
 def bake_rotation_to_mesh(object_name):
@@ -33,3 +33,42 @@ def bake_rotation_to_mesh(object_name):
         return True
     except Exception:
         return False
+
+
+def make_euler_orientation(rx, ry, rz, default_fn=None):
+    """
+    Build an orientation callable for any morphospace: run Default (if given), then apply
+    Euler (rx, ry, rz) in the object's **local** frame (relative to the post-Default pose,
+    before bake), then origin at geometry bounds and table center.
+
+    Local composition uses ``R_obj @ R_local`` so axes follow the specimen after Default
+    (works for Shell aperture alignment, ATLAS table Default, etc.).
+
+    Args:
+        rx, ry, rz: Local Euler rotation in radians (object rotation_euler order).
+        default_fn: Optional morphospace Default orientation callable.
+
+    Returns:
+        callable: ``orient(sample_obj)``
+    """
+    rx_f, ry_f, rz_f = float(rx), float(ry), float(rz)
+
+    def orient(sample_obj):
+        if callable(default_fn):
+            default_fn(sample_obj)
+        else:
+            sample_obj.tb_location = (0.0, 0.0, 0.0)
+
+        order = sample_obj.rotation_euler.order
+        R_obj = sample_obj.rotation_euler.to_matrix()
+        R_local = Euler((rx_f, ry_f, rz_f), order).to_matrix()
+        sample_obj.rotation_euler = (R_obj @ R_local).to_euler(order)
+
+        bpy.context.view_layer.objects.active = sample_obj
+        sample_obj.select_set(True)
+        bpy.ops.object.origin_set(type="ORIGIN_GEOMETRY", center="BOUNDS")
+        sample_obj.tb_location = (0.0, 0.0, 0.0)
+        bpy.context.view_layer.update()
+
+    orient.__name__ = f"_orient_custom_local_euler_{rx_f:.4f}_{ry_f:.4f}_{rz_f:.4f}"
+    return orient

--- a/traitblender/core/helpers/render_engine_compat.py
+++ b/traitblender/core/helpers/render_engine_compat.py
@@ -1,65 +1,156 @@
 """
 Blender version differences: Eevee render.engine enum id varies (BLENDER_EEVEE_NEXT vs BLENDER_EEVEE).
+
+IMPORTANT (Blender 5.1+): ``RenderSettings.engine`` RNA ``enum_items`` often only
+lists the *currently selected* engine (e.g. ``['BLENDER_EEVEE']``), not every
+installed engine. Never use that list to decide that CYCLES is "invalid" — direct
+assignment ``scene.render.engine = "CYCLES"`` still works.
 """
 
 from __future__ import annotations
 
 import bpy
 
+# Stable EnumProperty numbers for get/set (not list indices).
+ENGINE_NUM_CYCLES = 0
+ENGINE_NUM_EEVEE = 1
+ENGINE_NUM_WORKBENCH = 2
+
+# Known engine identifiers (assignment targets). Not derived from incomplete RNA enums.
+_KNOWN_ENGINES = (
+    "CYCLES",
+    "BLENDER_EEVEE",
+    "BLENDER_EEVEE_NEXT",
+    "BLENDER_WORKBENCH",
+)
+
+# Keep a hard reference to dynamic enum item strings (Blender requirement).
+_RENDER_ENGINE_ITEMS_CACHE: list[tuple] = []
+
 
 def _engine_enum_identifiers() -> list[str]:
+    """
+    Best-effort RNA identifiers for render.engine.
+
+    May be incomplete on Blender 5.1+ (often only the active engine). Prefer
+    ``_KNOWN_ENGINES`` / try-assign for apply paths.
+    """
+    ids: list[str] = []
     try:
-        prop = bpy.types.RenderSettings.bl_rna.properties["engine"]
-        return [item.identifier for item in prop.enum_items]
+        scene = bpy.context.scene
+        prop = scene.render.bl_rna.properties["engine"]
+        ids = [item.identifier for item in prop.enum_items]
     except Exception:
-        return []
+        pass
+    if not ids:
+        try:
+            prop = bpy.types.RenderSettings.bl_rna.properties["engine"]
+            ids = [item.identifier for item in prop.enum_items]
+        except Exception:
+            ids = []
+    return ids
 
 
 def get_eevee_engine_identifier() -> str:
     ids = set(_engine_enum_identifiers())
-    if "BLENDER_EEVEE_NEXT" in ids:
-        return "BLENDER_EEVEE_NEXT"
+    # Prefer whatever RNA currently exposes; else Blender 5 name, then legacy.
     if "BLENDER_EEVEE" in ids:
         return "BLENDER_EEVEE"
+    if "BLENDER_EEVEE_NEXT" in ids:
+        return "BLENDER_EEVEE_NEXT"
+    # Blender 5 UI label is EEVEE; identifier is typically BLENDER_EEVEE.
     return "BLENDER_EEVEE"
 
 
-def render_engine_enum_items() -> list[tuple[str, str, str]]:
+def render_engine_enum_items() -> list[tuple]:
+    """
+    Enum items with stable integer ids for get/set callbacks.
+
+    Blender EnumProperty get/set must return/accept these numbers (4th tuple
+    element), not list indices. Keep a module reference so dynamic callbacks
+    do not crash Blender.
+    """
+    global _RENDER_ENGINE_ITEMS_CACHE
     eevee = get_eevee_engine_identifier()
-    return [
-        ("CYCLES", "Cycles", "Cycles"),
-        (eevee, "Eevee", "Eevee"),
-        ("BLENDER_WORKBENCH", "Workbench", "Workbench"),
+    _RENDER_ENGINE_ITEMS_CACHE = [
+        ("CYCLES", "Cycles", "Cycles", ENGINE_NUM_CYCLES),
+        (eevee, "Eevee", "Eevee", ENGINE_NUM_EEVEE),
+        ("BLENDER_WORKBENCH", "Workbench", "Workbench", ENGINE_NUM_WORKBENCH),
     ]
+    return _RENDER_ENGINE_ITEMS_CACHE
 
 
 def render_engine_options() -> list[str]:
     return [item[0] for item in render_engine_enum_items()]
 
 
+def render_engine_number_for_identifier(identifier: str) -> int:
+    ident = normalize_render_engine_value(identifier)
+    for item in render_engine_enum_items():
+        if item[0] == ident:
+            return item[3]
+    return ENGINE_NUM_CYCLES
+
+
+def render_engine_identifier_for_number(number: int) -> str:
+    for item in render_engine_enum_items():
+        if item[3] == number:
+            return item[0]
+    return "CYCLES"
+
+
 def normalize_render_engine_value(value) -> str:
     """
-    Map a config/YAML engine value to a valid bpy.context.scene.render.engine identifier
-    for this Blender build.
+    Map a config/YAML engine value to a ``scene.render.engine`` identifier.
+
+    Does **not** demote known engines (e.g. CYCLES) to Eevee when RNA
+    ``enum_items`` is incomplete — that was breaking Configure Scene on 5.1.
     """
-    ids = _engine_enum_identifiers()
-    avail = set(ids)
     eevee = get_eevee_engine_identifier()
     ordered = ["CYCLES", eevee, "BLENDER_WORKBENCH"]
 
     if isinstance(value, int):
         if 0 <= value < len(ordered):
-            candidate = ordered[value]
-            return candidate if candidate in avail else (ordered[0] if ordered[0] in avail else ids[0])
-        return eevee if eevee in avail else "CYCLES"
+            return ordered[value]
+        return "CYCLES"
 
     s = str(value).strip()
-    if s in avail:
-        return s
-    if s == "BLENDER_EEVEE_NEXT" and "BLENDER_EEVEE" in avail:
-        return "BLENDER_EEVEE"
-    if s == "BLENDER_EEVEE" and "BLENDER_EEVEE_NEXT" in avail:
-        return "BLENDER_EEVEE_NEXT"
-    if eevee in avail:
+    if not s:
+        return "CYCLES"
+
+    # Friendly aliases
+    upper = s.upper()
+    if upper in ("EEVEE", "EEVEE_NEXT", "BLENDER_EEVEE", "BLENDER_EEVEE_NEXT"):
+        if s in ("BLENDER_EEVEE", "BLENDER_EEVEE_NEXT"):
+            # Prefer the id this build actually uses when we can see it
+            ids = set(_engine_enum_identifiers())
+            if s in ids:
+                return s
+            if "BLENDER_EEVEE" in ids:
+                return "BLENDER_EEVEE"
+            if "BLENDER_EEVEE_NEXT" in ids:
+                return "BLENDER_EEVEE_NEXT"
+            return eevee
         return eevee
-    return "CYCLES" if "CYCLES" in avail else (ids[0] if ids else "CYCLES")
+    if upper == "CYCLES":
+        return "CYCLES"
+    if upper in ("WORKBENCH", "BLENDER_WORKBENCH"):
+        return "BLENDER_WORKBENCH"
+
+    if s in _KNOWN_ENGINES:
+        return s
+
+    # Unknown string: keep as-is so assignment can succeed or fail loudly
+    return s
+
+
+def try_set_render_engine(scene, engine) -> str:
+    """
+    Assign ``scene.render.engine`` and return the value that stuck.
+
+    Raises:
+        Exception: If assignment fails.
+    """
+    wanted = normalize_render_engine_value(engine)
+    scene.render.engine = wanted
+    return scene.render.engine

--- a/traitblender/core/morphospaces/__init__.py
+++ b/traitblender/core/morphospaces/__init__.py
@@ -2,6 +2,7 @@ from .list_morphospaces import list_morphospaces
 from .get_orientations import (
     get_orientations_for_morphospace,
     get_orientation_names,
+    get_builtin_orientation_names,
 )
 from .apply_orientation import apply_orientation_by_name
 from .get_hyperparams import get_hyperparameters_for_morphospace
@@ -16,6 +17,7 @@ __all__ = [
     'list_morphospaces',
     'get_orientations_for_morphospace',
     'get_orientation_names',
+    'get_builtin_orientation_names',
     'apply_orientation_by_name',
     'get_hyperparameters_for_morphospace',
     'get_morphospace_display_name',

--- a/traitblender/core/morphospaces/__init__.py
+++ b/traitblender/core/morphospaces/__init__.py
@@ -3,6 +3,7 @@ from .get_orientations import (
     get_orientations_for_morphospace,
     get_orientation_names,
 )
+from .apply_orientation import apply_orientation_by_name
 from .get_hyperparams import get_hyperparameters_for_morphospace
 from .get_display_name import get_morphospace_display_name
 from .trait_params import (
@@ -15,6 +16,7 @@ __all__ = [
     'list_morphospaces',
     'get_orientations_for_morphospace',
     'get_orientation_names',
+    'apply_orientation_by_name',
     'get_hyperparameters_for_morphospace',
     'get_morphospace_display_name',
     'get_trait_parameters_for_morphospace',

--- a/traitblender/core/morphospaces/apply_orientation.py
+++ b/traitblender/core/morphospaces/apply_orientation.py
@@ -1,0 +1,92 @@
+"""
+Apply a named morphospace orientation to the current sample.
+
+Single source of truth: look up the callable by ``orientation_name`` from
+``get_orientations_for_morphospace``, apply it, and return that same name
+for callers to use for folders / logs / CSV.
+"""
+
+from __future__ import annotations
+
+import bpy
+from mathutils import Euler
+
+from .get_orientations import get_orientations_for_morphospace
+from ..helpers import bake_rotation_to_mesh
+
+
+def apply_orientation_by_name(context, orientation_name, sample_name=None, morphospace_name=None):
+    """
+    Reset the sample to rest, apply the named orientation, bake rotation.
+
+    Args:
+        context: Blender context.
+        orientation_name: Exact key in the morphospace ORIENTATIONS merge
+            (built-ins + customs). Used for both the lookup and as the return value.
+        sample_name: Object name; defaults to ``scene.traitblender_dataset.sample``.
+        morphospace_name: Morphospace id; defaults to setup selection.
+
+    Returns:
+        str: The ``orientation_name`` that was applied (same string passed in).
+
+    Raises:
+        ValueError: Missing sample, unknown orientation, or non-callable entry.
+    """
+    scene = context.scene
+    dataset = scene.traitblender_dataset
+    setup = scene.traitblender_setup
+
+    if not orientation_name:
+        raise ValueError("No orientation name provided")
+
+    if sample_name is None:
+        sample_name = dataset.sample
+    if not sample_name:
+        raise ValueError("No sample selected in dataset")
+    if sample_name not in bpy.data.objects:
+        raise ValueError(f"Sample object '{sample_name}' not found in scene")
+
+    if morphospace_name is None:
+        morphospace_name = setup.available_morphospaces
+    if not morphospace_name:
+        raise ValueError("No morphospace selected")
+
+    orientations = get_orientations_for_morphospace(morphospace_name, context=context)
+    if orientation_name not in orientations:
+        raise ValueError(
+            f"Orientation '{orientation_name}' not found for morphospace '{morphospace_name}'"
+        )
+
+    orient_func = orientations[orientation_name]
+    if not callable(orient_func):
+        raise ValueError(f"Orientation '{orientation_name}' is not callable")
+
+    sample_obj = bpy.data.objects[sample_name]
+    sample_data = scene.traitblender_sample
+
+    if bpy.context.mode != 'OBJECT':
+        bpy.ops.object.mode_set(mode='OBJECT')
+    bpy.ops.object.select_all(action='DESELECT')
+    sample_obj.select_set(True)
+    bpy.context.view_layer.objects.active = sample_obj
+
+    last_baked = sample_data.last_baked_rotation
+    if (last_baked[0], last_baked[1], last_baked[2]) != (0.0, 0.0, 0.0):
+        eul = Euler(last_baked)
+        inv_rot = eul.to_matrix().inverted()
+        sample_obj.rotation_euler = inv_rot.to_euler(eul.order)
+        bpy.ops.object.transform_apply(rotation=True)
+        sample_data.last_baked_rotation = (0.0, 0.0, 0.0)
+
+    sample_obj.rotation_euler = Euler(sample_data.rest_rotation)
+    bpy.context.view_layer.update()
+
+    orient_func(sample_obj)
+    bpy.context.view_layer.update()
+
+    sample_data.last_baked_rotation = tuple(sample_obj.rotation_euler)
+    bake_rotation_to_mesh(sample_name)
+    bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY', center='BOUNDS')
+    bpy.context.view_layer.update()
+
+    return orientation_name

--- a/traitblender/core/morphospaces/get_orientations.py
+++ b/traitblender/core/morphospaces/get_orientations.py
@@ -1,28 +1,83 @@
-"""Orientation functions for morphospaces."""
+"""Orientation functions for morphospaces (built-in + config custom Eulers)."""
 
 from ._module_loader import load_morphospace_module
+from ..helpers.orientation_helpers import make_euler_orientation
 
 
-def get_orientations_for_morphospace(morphospace_name):
+def _custom_orientations_from_context(context):
     """
-    Get the ORIENTATIONS dictionary from a morphospace module.
-    
+    Read imaging.custom_orientations from the scene config.
+
+    Returns:
+        dict: {name: (rx, ry, rz)} for non-empty names
+    """
+    if context is None:
+        try:
+            import bpy
+
+            context = bpy.context
+        except Exception:
+            return {}
+    try:
+        imaging = context.scene.traitblender_config.imaging
+    except Exception:
+        return {}
+
+    out = {}
+    for item in getattr(imaging, "custom_orientations", []) or []:
+        name = (getattr(item, "name", "") or "").strip()
+        if not name:
+            continue
+        rot = getattr(item, "rotation", (0.0, 0.0, 0.0))
+        out[name] = (float(rot[0]), float(rot[1]), float(rot[2]))
+    return out
+
+
+def get_orientations_for_morphospace(morphospace_name, context=None):
+    """
+    Get the ORIENTATIONS dictionary for a morphospace, merged with custom local Eulers
+    from ``scene.traitblender_config.imaging.custom_orientations``.
+
     Morphospace modules must export ORIENTATIONS with at least "Default": callable.
     Each callable receives (sample_obj) and orients the object in place.
-    
+
+    Customs run Default, then compose ``(rx, ry, rz)`` in the object's local frame
+    (relative to the post-Default pose, before bake). Custom names that collide with
+    built-in orientation names are skipped (built-ins win).
+
+    Args:
+        morphospace_name: Morphospace folder id or display name.
+        context: Optional Blender context (defaults to ``bpy.context``).
+
     Returns:
-        dict: ORIENTATIONS from the module, or empty dict if not defined/failed
+        dict: name -> callable, or empty dict if not defined/failed
     """
     module = load_morphospace_module(morphospace_name)
     if module is None:
         return {}
-    return getattr(module, 'ORIENTATIONS', {})
+
+    base = dict(getattr(module, "ORIENTATIONS", {}) or {})
+    if not base:
+        return {}
+
+    default_fn = base.get("Default")
+    customs = _custom_orientations_from_context(context)
+    for name, (rx, ry, rz) in customs.items():
+        if name in base:
+            print(
+                f"TraitBlender: Custom orientation '{name}' skipped "
+                f"(name already used by a built-in orientation)."
+            )
+            continue
+        base[name] = make_euler_orientation(rx, ry, rz, default_fn=default_fn)
+
+    return base
 
 
-def get_orientation_names(morphospace_name):
+def get_orientation_names(morphospace_name, context=None):
     """
-    Get list of orientation names for a morphospace (for pipeline iteration, etc.).
-    Returns e.g. ['Default', ...].
+    Get list of orientation names for a morphospace (built-ins + customs).
+    Returns e.g. ['Default', ..., 'Side'].
     """
-    orientations = get_orientations_for_morphospace(morphospace_name)
+    orientations = get_orientations_for_morphospace(morphospace_name, context=context)
     return list(orientations.keys()) if orientations else []

--- a/traitblender/core/morphospaces/get_orientations.py
+++ b/traitblender/core/morphospaces/get_orientations.py
@@ -33,6 +33,20 @@ def _custom_orientations_from_context(context):
     return out
 
 
+def get_builtin_orientation_names(morphospace_name):
+    """
+    Built-in ORIENTATIONS keys for a morphospace (no custom Eulers).
+
+    Returns:
+        list[str]: e.g. ['Default', ...], or empty if unavailable.
+    """
+    module = load_morphospace_module(morphospace_name)
+    if module is None:
+        return []
+    base = getattr(module, "ORIENTATIONS", {}) or {}
+    return list(base.keys()) if base else []
+
+
 def get_orientations_for_morphospace(morphospace_name, context=None):
     """
     Get the ORIENTATIONS dictionary for a morphospace, merged with custom local Eulers

--- a/traitblender/core/unit_test/__init__.py
+++ b/traitblender/core/unit_test/__init__.py
@@ -1,0 +1,86 @@
+"""
+TraitBlender in-addon unit tests.
+
+Each module exposes a test callable ``test_*(context=None) -> dict``.
+``TESTS`` maps stable names to those callables.
+
+Pass ``test_name="help"`` to ``run_test`` / the operator to list all tests
+and their docstrings.
+"""
+
+from .test_config_matches_scene import test_config_matches_scene
+
+TESTS = {
+    "config_matches_scene": test_config_matches_scene,
+}
+
+HELP_NAME = "help"
+
+
+def list_tests():
+    """Return registered test names."""
+    return list(TESTS.keys())
+
+
+def help_tests() -> str:
+    """Return a printable catalog of test names and docstrings."""
+    lines = ["TraitBlender unit tests:", ""]
+    if not TESTS:
+        lines.append("  (none registered)")
+        return "\n".join(lines)
+
+    for name in list_tests():
+        fn = TESTS[name]
+        doc = (getattr(fn, "__doc__", None) or "").strip() or "(no docstring)"
+        doc_lines = [ln.rstrip() for ln in doc.splitlines()]
+        lines.append(f"  {name}")
+        for ln in doc_lines:
+            lines.append(f"    {ln}" if ln else "")
+        lines.append("")
+    lines.append('Run: bpy.ops.traitblender.run_unit_test(test_name="<name>")')
+    lines.append(f'Help: bpy.ops.traitblender.run_unit_test(test_name="{HELP_NAME}")')
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def run_test(name, context=None):
+    """
+    Run a registered test by name.
+
+    Args:
+        name: Key in ``TESTS``, or ``\"help\"`` to list tests and docstrings.
+        context: Optional Blender context.
+
+    Returns:
+        dict: Test result (at least ``passed`` and ``message``).
+        For ``help``, ``passed`` is True and ``message`` is the catalog text.
+
+    Raises:
+        KeyError: Unknown test name.
+    """
+    key = (name or "").strip()
+    if key.lower() == HELP_NAME:
+        message = help_tests()
+        return {
+            "name": HELP_NAME,
+            "passed": True,
+            "mismatches": [],
+            "message": message,
+            "help": True,
+        }
+    if key not in TESTS:
+        known = ", ".join(list_tests()) or "(none)"
+        raise KeyError(
+            f"Unknown unit test '{name}'. Known: {known}. "
+            f'Use test_name="{HELP_NAME}" for details.'
+        )
+    return TESTS[key](context)
+
+
+__all__ = [
+    "TESTS",
+    "HELP_NAME",
+    "list_tests",
+    "help_tests",
+    "run_test",
+    "test_config_matches_scene",
+]

--- a/traitblender/core/unit_test/test_config_matches_scene.py
+++ b/traitblender/core/unit_test/test_config_matches_scene.py
@@ -1,0 +1,299 @@
+"""
+Compare the YAML config file on disk to the live scene / TraitBlender config.
+
+Reports paths where expected (file) and actual (scene) differ.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import bpy
+import yaml
+
+from ..helpers.render_engine_compat import normalize_render_engine_value
+
+
+def _as_list(value) -> list:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    try:
+        return list(value)
+    except Exception:
+        return [value]
+
+
+def _values_equal(expected: Any, actual: Any, *, rtol: float = 1e-5, atol: float = 1e-6) -> bool:
+    """Loose equality for YAML vs Blender RNA values."""
+    if expected is None and actual is None:
+        return True
+
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        return bool(expected) == bool(actual)
+
+    if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
+        return abs(float(expected) - float(actual)) <= (atol + rtol * abs(float(expected)))
+
+    if isinstance(expected, (list, tuple)) or (
+        actual is not None
+        and hasattr(actual, "__iter__")
+        and not isinstance(actual, (str, bytes, dict))
+    ):
+        exp_l = _as_list(expected)
+        act_l = _as_list(actual)
+        if len(exp_l) != len(act_l):
+            return False
+        return all(_values_equal(a, b, rtol=rtol, atol=atol) for a, b in zip(exp_l, act_l))
+
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        if set(expected.keys()) != set(actual.keys()):
+            return False
+        return all(_values_equal(expected[k], actual[k], rtol=rtol, atol=atol) for k in expected)
+
+    return str(expected).strip() == str(actual).strip()
+
+
+def _fmt(value: Any) -> str:
+    if isinstance(value, float):
+        return repr(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ", ".join(_fmt(v) for v in value) + "]"
+    return repr(value)
+
+
+def _normalize_actual(actual: Any) -> Any:
+    if actual is None or isinstance(actual, (str, bool, int, float, dict)):
+        return actual
+    if hasattr(actual, "__iter__"):
+        return _as_list(actual)
+    return actual
+
+
+def _live_imaging_snapshot(imaging) -> dict:
+    customs = {}
+    for item in imaging.custom_orientations:
+        name = (item.name or "").strip()
+        if not name:
+            continue
+        customs[name] = [
+            float(item.rotation[0]),
+            float(item.rotation[1]),
+            float(item.rotation[2]),
+        ]
+    return {
+        "include_images": bool(imaging.include_images),
+        "orientation_names": [item.name for item in imaging.orientation_options if item.enabled],
+        "images_per_orientation": int(imaging.images_per_orientation),
+        "custom_orientations": customs,
+    }
+
+
+def _live_morphospace_snapshot(morphospace) -> dict:
+    try:
+        hyper = dict(morphospace._get_hyperparams_dict() or {})
+    except Exception:
+        hyper = {}
+    return {
+        "name": morphospace.name,
+        "hyperparams": hyper,
+    }
+
+
+def _live_value(section, key: str, context):
+    """Read one YAML-schema field from a live config section / scene."""
+    cls_name = section.__class__.__name__
+
+    if cls_name == "RenderConfig" and key == "engine":
+        return normalize_render_engine_value(context.scene.render.engine)
+
+    if cls_name == "ImagingConfig":
+        snap = _live_imaging_snapshot(section)
+        if key in snap:
+            return snap[key]
+
+    if cls_name == "MorphospaceConfig":
+        snap = _live_morphospace_snapshot(section)
+        if key in snap:
+            return snap[key]
+
+    return getattr(section, key)
+
+
+def _add_mismatch(mismatches, path, expected, actual, reason):
+    mismatches.append(
+        {
+            "path": path,
+            "expected": expected,
+            "actual": _normalize_actual(actual),
+            "reason": reason,
+        }
+    )
+
+
+def _compare_section(path: str, expected: dict, section, context, mismatches: list) -> None:
+    """Compare a YAML mapping to one live config PropertyGroup section."""
+    for key, exp_val in expected.items():
+        if key == "show":
+            continue
+        child_path = f"{path}.{key}" if path else key
+
+        if key == "hyperparams" and isinstance(exp_val, dict):
+            actual = _live_morphospace_snapshot(section).get("hyperparams", {})
+            for hk, hv in exp_val.items():
+                hpath = f"{child_path}.{hk}"
+                if hk not in actual:
+                    _add_mismatch(mismatches, hpath, hv, None, "hyperparam missing in live config")
+                elif not _values_equal(hv, actual[hk]):
+                    _add_mismatch(mismatches, hpath, hv, actual[hk], "value mismatch")
+            continue
+
+        if key == "custom_orientations" and isinstance(exp_val, dict):
+            actual_customs = _live_imaging_snapshot(section).get("custom_orientations", {})
+            for name, rot in exp_val.items():
+                cpath = f"{child_path}.{name}"
+                if name not in actual_customs:
+                    _add_mismatch(
+                        mismatches, cpath, rot, None, "custom orientation missing in live config"
+                    )
+                elif not _values_equal(rot, actual_customs[name]):
+                    _add_mismatch(mismatches, cpath, rot, actual_customs[name], "value mismatch")
+            continue
+
+        if key == "orientation_names":
+            try:
+                actual = _live_value(section, key, context)
+            except Exception as e:
+                _add_mismatch(mismatches, child_path, exp_val, None, f"failed to read: {e}")
+                continue
+            exp_set = set(exp_val) if isinstance(exp_val, list) else set()
+            act_set = set(actual) if isinstance(actual, list) else set()
+            if exp_set != act_set:
+                _add_mismatch(
+                    mismatches,
+                    child_path,
+                    sorted(exp_set),
+                    sorted(act_set),
+                    "enabled orientation set mismatch",
+                )
+            continue
+
+        try:
+            actual = _live_value(section, key, context)
+        except Exception as e:
+            _add_mismatch(mismatches, child_path, exp_val, None, f"failed to read: {e}")
+            continue
+
+        if not _values_equal(exp_val, actual):
+            reason = "value mismatch"
+            if key == "engine" and section.__class__.__name__ == "RenderConfig":
+                try:
+                    rna_ids = sorted(
+                        item.identifier
+                        for item in context.scene.render.bl_rna.properties["engine"].enum_items
+                    )
+                except Exception:
+                    rna_ids = []
+                reason = (
+                    "value mismatch (test only compares; it does not apply YAML — "
+                    "run bpy.ops.traitblender.configure_scene() first). "
+                    f"scene.render.engine={context.scene.render.engine!r}; "
+                    f"RNA engines={rna_ids}"
+                )
+            _add_mismatch(mismatches, child_path, exp_val, actual, reason)
+
+
+# Sections that are UI-only / not meaningful to compare from YAML
+_SKIP_ROOT_KEYS = frozenset({"sample"})
+
+
+def _compare_root(expected: dict, root, context, mismatches: list) -> None:
+    annotations = getattr(root.__class__, "__annotations__", {}) or {}
+
+    for key, exp_val in expected.items():
+        if key in _SKIP_ROOT_KEYS:
+            continue
+        # Bare `sample:` / null section in YAML — nothing to check
+        if exp_val is None:
+            continue
+
+        if key not in annotations:
+            _add_mismatch(
+                mismatches, key, exp_val, None, "key not present on live TraitBlender config"
+            )
+            continue
+
+        section = getattr(root, key, None)
+        if section is None:
+            _add_mismatch(mismatches, key, exp_val, None, "live section is None")
+            continue
+
+        if isinstance(exp_val, dict) and callable(getattr(section, "from_dict", None)):
+            _compare_section(key, exp_val, section, context, mismatches)
+            continue
+
+        # Non-dict root fields (e.g. transforms list)
+        try:
+            actual = getattr(root, key)
+        except Exception as e:
+            _add_mismatch(mismatches, key, exp_val, None, f"failed to read: {e}")
+            continue
+        if not _values_equal(exp_val, actual):
+            _add_mismatch(mismatches, key, exp_val, actual, "value mismatch")
+
+
+def test_config_matches_scene(context=None) -> dict:
+    """
+    Load ``traitblender_setup.config_file`` and compare each YAML field to the
+    live scene / TraitBlender config values.
+
+    Returns:
+        dict with keys: name, passed, mismatches, message, config_file
+    """
+    context = context or bpy.context
+    setup = context.scene.traitblender_setup
+    config_file = (setup.config_file or "").strip()
+    result = {
+        "name": "config_matches_scene",
+        "passed": False,
+        "mismatches": [],
+        "message": "",
+        "config_file": config_file,
+    }
+
+    if not config_file:
+        result["message"] = "No config file set on traitblender_setup.config_file"
+        return result
+    if not os.path.isfile(config_file):
+        result["message"] = f"Config file not found: {config_file}"
+        return result
+
+    try:
+        with open(config_file, "r", encoding="utf-8") as f:
+            expected = yaml.safe_load(f)
+    except Exception as e:
+        result["message"] = f"Failed to read config YAML: {e}"
+        return result
+
+    if not isinstance(expected, dict):
+        result["message"] = "Config YAML root must be a mapping"
+        return result
+
+    mismatches: list = []
+    _compare_root(expected, context.scene.traitblender_config, context, mismatches)
+
+    result["mismatches"] = mismatches
+    result["passed"] = len(mismatches) == 0
+    if result["passed"]:
+        result["message"] = f"All checked fields match scene ({config_file})"
+    else:
+        lines = [f"{len(mismatches)} mismatch(es) vs {config_file}:"]
+        for m in mismatches:
+            lines.append(
+                f"  - {m['path']}: expected {_fmt(m['expected'])}, "
+                f"actual {_fmt(m['actual'])} ({m.get('reason', 'mismatch')})"
+            )
+        result["message"] = "\n".join(lines)
+    return result

--- a/traitblender/core/unit_test/test_config_matches_scene.py
+++ b/traitblender/core/unit_test/test_config_matches_scene.py
@@ -109,6 +109,17 @@ def _live_value(section, key: str, context):
     if cls_name == "RenderConfig" and key == "engine":
         return normalize_render_engine_value(context.scene.render.engine)
 
+    # Always compare Cycles/Eevee YAML keys to live scene RNA (not PropertyGroup getters).
+    if cls_name == "CyclesRenderConfig":
+        cycles = getattr(context.scene, "cycles", None)
+        if cycles is not None and hasattr(cycles, key):
+            return getattr(cycles, key)
+
+    if cls_name == "EeveeRenderConfig":
+        eevee = getattr(context.scene, "eevee", None)
+        if eevee is not None and hasattr(eevee, key):
+            return getattr(eevee, key)
+
     if cls_name == "ImagingConfig":
         snap = _live_imaging_snapshot(section)
         if key in snap:
@@ -180,11 +191,77 @@ def _compare_section(path: str, expected: dict, section, context, mismatches: li
                 )
             continue
 
+        # Nested config subsection (e.g. render.cycles / render.eevee)
+        if isinstance(exp_val, dict):
+            # Prefer comparing Cycles/Eevee blocks straight to scene RNA.
+            if path == "render" and key == "cycles":
+                cycles = getattr(context.scene, "cycles", None)
+                if cycles is None:
+                    _add_mismatch(
+                        mismatches, child_path, exp_val, None, "scene.cycles is missing"
+                    )
+                    continue
+                for ck, cv in exp_val.items():
+                    cpath = f"{child_path}.{ck}"
+                    if not hasattr(cycles, ck):
+                        _add_mismatch(
+                            mismatches, cpath, cv, None, f"scene.cycles has no attribute {ck!r}"
+                        )
+                        continue
+                    try:
+                        actual = getattr(cycles, ck)
+                    except Exception as e:
+                        _add_mismatch(mismatches, cpath, cv, None, f"failed to read: {e}")
+                        continue
+                    if not _values_equal(cv, actual):
+                        _add_mismatch(mismatches, cpath, cv, actual, "value mismatch")
+                continue
+
+            if path == "render" and key == "eevee":
+                eevee = getattr(context.scene, "eevee", None)
+                if eevee is None:
+                    _add_mismatch(
+                        mismatches, child_path, exp_val, None, "scene.eevee is missing"
+                    )
+                    continue
+                for ek, ev in exp_val.items():
+                    epath = f"{child_path}.{ek}"
+                    if not hasattr(eevee, ek):
+                        _add_mismatch(
+                            mismatches, epath, ev, None, f"scene.eevee has no attribute {ek!r}"
+                        )
+                        continue
+                    try:
+                        actual = getattr(eevee, ek)
+                    except Exception as e:
+                        _add_mismatch(mismatches, epath, ev, None, f"failed to read: {e}")
+                        continue
+                    if not _values_equal(ev, actual):
+                        _add_mismatch(mismatches, epath, ev, actual, "value mismatch")
+                continue
+
+            child = getattr(section, key, None)
+            if child is not None and callable(getattr(child, "from_dict", None)):
+                _compare_section(child_path, exp_val, child, context, mismatches)
+                continue
+            _add_mismatch(
+                mismatches,
+                child_path,
+                exp_val,
+                None,
+                "nested mapping could not be compared (no matching subsection)",
+            )
+            continue
+
         try:
             actual = _live_value(section, key, context)
         except Exception as e:
             _add_mismatch(mismatches, child_path, exp_val, None, f"failed to read: {e}")
             continue
+
+        if key == "engine" and section.__class__.__name__ == "RenderConfig":
+            # already handled via _live_value
+            pass
 
         if not _values_equal(exp_val, actual):
             reason = "value mismatch"
@@ -205,7 +282,8 @@ def _compare_section(path: str, expected: dict, section, context, mismatches: li
             _add_mismatch(mismatches, child_path, exp_val, actual, reason)
 
 
-# Sections that are UI-only / not meaningful to compare from YAML
+# Sections that are UI-only / not meaningful to compare from YAML.
+# Bare ``sample:`` (null) or ``sample: {}`` must never count as a mismatch.
 _SKIP_ROOT_KEYS = frozenset({"sample"})
 
 
@@ -215,8 +293,8 @@ def _compare_root(expected: dict, root, context, mismatches: list) -> None:
     for key, exp_val in expected.items():
         if key in _SKIP_ROOT_KEYS:
             continue
-        # Bare `sample:` / null section in YAML — nothing to check
-        if exp_val is None:
+        # Bare section keys like `sample:` → None, or empty `{}` — nothing to check
+        if exp_val is None or exp_val == {}:
             continue
 
         if key not in annotations:

--- a/traitblender/docs/api/scene-assets.md
+++ b/traitblender/docs/api/scene-assets.md
@@ -210,4 +210,4 @@ This reference focuses on the user-facing operators and properties you will use 
 
 - The [Python tooltip](../getting-started/blender-optimization.md#python-tooltips) in Blender is usually enough to discover the matching API call for a given button or property.
 - TraitBlender assumes a **single active scene** (and view layer). Config, operators, imaging sync, and orientations all use that context—multi-scene setups are not supported.
-- Custom orientation names should be simple identifiers (letters, digits, `_`, `-`) so YAML export/import round-trips; see [Configuration Files](../configuration/config-files.md#custom-orientations-in-yaml).
+- Custom orientation names must be unique identifiers (letters, digits, `_`, `-` only) and must not collide with built-ins; see [Configuration Files](../configuration/config-files.md#custom-orientations-in-yaml).

--- a/traitblender/docs/api/scene-assets.md
+++ b/traitblender/docs/api/scene-assets.md
@@ -203,5 +203,4 @@ This reference focuses on the user-facing operators and properties you will use 
 
 ## Notes
 
-- The Python tooltip in Blender is usually enough to discover the matching API call for a given button or property.
-- After loading a config, use [`bpy.ops.traitblender.run_unit_test`](../configuration/unit-tests.md) (`config_matches_scene`) to verify YAML vs the live scene.
+- The [Python tooltip](../getting-started/blender-optimization.md#python-tooltips) in Blender is usually enough to discover the matching API call for a given button or property.

--- a/traitblender/docs/api/scene-assets.md
+++ b/traitblender/docs/api/scene-assets.md
@@ -56,8 +56,18 @@ This reference focuses on the user-facing operators and properties you will use 
 
 <hr>
 
-<p><code>bpy.ops.traitblender.apply_orientation()</code></p>
-<p>Apply the selected morphospace orientation to the current sample.</p>
+<p><code>bpy.ops.traitblender.apply_orientation(orientation="")</code></p>
+<p>Apply a named morphospace orientation to the current sample. Pass <code>orientation</code> explicitly (recommended for scripts/pipeline); if empty, uses the Orientations panel selection. Folders and logs should use the same name string that was applied.</p>
+
+<hr>
+
+<p><code>bpy.context.scene.traitblender_config.imaging.custom_orientations</code></p>
+<p>Named custom Euler orientations (<code>name</code>, <code>rotation</code> as <code>[rx, ry, rz]</code> radians). Applied in the specimen's local frame after Default (before bake). Merged with built-in morphospace orientations for Apply and the imaging pipeline.</p>
+
+<hr>
+
+<p><code>bpy.ops.traitblender.add_custom_orientation()</code> / <code>bpy.ops.traitblender.remove_custom_orientation()</code></p>
+<p>Add or remove a custom orientation entry.</p>
 
 </details>
 

--- a/traitblender/docs/api/scene-assets.md
+++ b/traitblender/docs/api/scene-assets.md
@@ -204,3 +204,5 @@ This reference focuses on the user-facing operators and properties you will use 
 ## Notes
 
 - The [Python tooltip](../getting-started/blender-optimization.md#python-tooltips) in Blender is usually enough to discover the matching API call for a given button or property.
+- TraitBlender assumes a **single active scene** (and view layer). Config, operators, imaging sync, and orientations all use that context—multi-scene setups are not supported.
+- Custom orientation names should be simple identifiers (letters, digits, `_`, `-`) so YAML export/import round-trips; see [Configuration Files](../configuration/config-files.md#custom-orientations-in-yaml).

--- a/traitblender/docs/api/scene-assets.md
+++ b/traitblender/docs/api/scene-assets.md
@@ -150,6 +150,11 @@ This reference focuses on the user-facing operators and properties you will use 
 
 <hr>
 
+<p><code>bpy.context.scene.traitblender_config.meshes.orient_before_export</code></p>
+<p>If <code>True</code> (default), apply Default orientation before pipeline mesh export (backward compatible). If <code>False</code>, export the generated mesh as-is—recommended for ATLAS PCA-aligned meshes. Does not affect imaging orientations used for renders. See <a href="../configuration/config-files.md#mesh-export-in-the-imaging-pipeline">Configuration Files</a>.</p>
+
+<hr>
+
 <p><code>bpy.ops.traitblender.export_mesh()</code></p>
 <p>Export the current sample as a mesh file using the selected format.</p>
 

--- a/traitblender/docs/api/scene-assets.md
+++ b/traitblender/docs/api/scene-assets.md
@@ -28,6 +28,16 @@ This reference focuses on the user-facing operators and properties you will use 
 
 <hr>
 
+<p><code>bpy.context.scene.traitblender_setup.config_file</code></p>
+<p>Path to the YAML used by <strong>Configure Scene</strong> and by the <code>config_matches_scene</code> unit test. After a successful configure (including via the file browser), this property is updated to the absolute path that was loaded.</p>
+
+<hr>
+
+<p><code>bpy.ops.traitblender.configure_scene(filepath="")</code></p>
+<p>Load a YAML config and apply it to the scene. If <code>filepath</code> is empty and <code>config_file</code> is unset, opens a file browser. Persists the chosen path on <code>traitblender_setup.config_file</code>.</p>
+
+<hr>
+
 <p><code>bpy.ops.traitblender.show_configuration()</code></p>
 <p>Print the current configuration as YAML for inspection or copying.</p>
 
@@ -35,6 +45,11 @@ This reference focuses on the user-facing operators and properties you will use 
 
 <p><code>bpy.ops.traitblender.export_config(filepath="")</code></p>
 <p>Export the current configuration to a YAML file.</p>
+
+<hr>
+
+<p><code>bpy.ops.traitblender.run_unit_test(test_name="help")</code></p>
+<p>Run an in-addon unit test by name. Use <code>test_name="help"</code> to list tests. See <a href="../configuration/unit-tests.md">Unit Tests</a>.</p>
 
 </details>
 
@@ -57,17 +72,17 @@ This reference focuses on the user-facing operators and properties you will use 
 <hr>
 
 <p><code>bpy.ops.traitblender.apply_orientation(orientation="")</code></p>
-<p>Apply a named morphospace orientation to the current sample. Pass <code>orientation</code> explicitly (recommended for scripts/pipeline); if empty, uses the Orientations panel selection. Folders and logs should use the same name string that was applied.</p>
+<p>Apply a named orientation to the current sample by <strong>name</strong> (built-in or custom). Pass <code>orientation</code> explicitly (recommended for scripts/pipeline); if empty, uses the Orientations panel selection. Imaging folders and logs should use the same name string that was applied.</p>
 
 <hr>
 
 <p><code>bpy.context.scene.traitblender_config.imaging.custom_orientations</code></p>
-<p>Named custom Euler orientations (<code>name</code>, <code>rotation</code> as <code>[rx, ry, rz]</code> radians). Applied in the specimen's local frame after Default (before bake). Merged with built-in morphospace orientations for Apply and the imaging pipeline.</p>
+<p>Named custom Euler orientations (<code>name</code>, <code>rotation</code> as <code>[rx, ry, rz]</code> radians). For every morphospace: run Default → apply Euler in the specimen's <strong>local</strong> frame (relative to the post-Default pose, before bake) → recenter at geometry bounds. Merged with built-ins for Apply and imaging; built-in names win on collision. YAML: <code>imaging.custom_orientations</code>.</p>
 
 <hr>
 
 <p><code>bpy.ops.traitblender.add_custom_orientation()</code> / <code>bpy.ops.traitblender.remove_custom_orientation()</code></p>
-<p>Add or remove a custom orientation entry.</p>
+<p>Add or remove a custom orientation entry in the Orientations panel (also reflected in Imaging checkboxes and YAML export).</p>
 
 </details>
 
@@ -167,7 +182,7 @@ This reference focuses on the user-facing operators and properties you will use 
 <hr>
 
 <p><code>bpy.context.scene.traitblender_setup</code></p>
-<p>Setup state for morphospace selection and scene initialization.</p>
+<p>Setup state for morphospace selection, <code>config_file</code>, and related UI.</p>
 
 <hr>
 
@@ -189,3 +204,4 @@ This reference focuses on the user-facing operators and properties you will use 
 ## Notes
 
 - The Python tooltip in Blender is usually enough to discover the matching API call for a given button or property.
+- After loading a config, use [`bpy.ops.traitblender.run_unit_test`](../configuration/unit-tests.md) (`config_matches_scene`) to verify YAML vs the live scene.

--- a/traitblender/docs/configuration/config-files.md
+++ b/traitblender/docs/configuration/config-files.md
@@ -110,7 +110,7 @@ TraitBlender config files are **YAML** files that store the settings you see in 
 <ul>
   <li><code>include_images</code>: boolean</li>
   <li><code>orientation_names</code>: list of strings (built-in and/or custom orientation names to include in the pipeline)</li>
-  <li><code>custom_orientations</code>: optional map of name → <code>[rx, ry, rz]</code> Euler angles in <strong>radians</strong>. Each custom orientation runs the morphospace Default, then applies the Euler in the specimen's <strong>local</strong> frame (relative to the post-Default pose, before bake), then recenters at geometry bounds. Available for all morphospaces; names must not collide with built-ins.</li>
+  <li><code>custom_orientations</code>: optional map of name → <code>[rx, ry, rz]</code> Euler angles in <strong>radians</strong>. Each custom orientation runs the morphospace Default, then applies the Euler in the specimen's <strong>local</strong> frame (relative to the post-Default pose, before bake), then recenters at geometry bounds. Available for all morphospaces; names must not collide with built-ins. Use simple keys: letters, digits, <code>_</code>, and <code>-</code> only (no spaces, quotes, or backslashes) so YAML export round-trips reliably.</li>
   <li><code>images_per_orientation</code>: integer, ≥ 1</li>
 </ul>
 
@@ -434,6 +434,8 @@ transforms: []
 ### Custom orientations in YAML
 
 Under `imaging.custom_orientations`, map a unique name to Euler angles `[rx, ry, rz]` in **radians**. Built-in morphospace orientation names always win on collision. Customs are available for every morphospace: they run **Default**, apply the Euler in the specimen’s **local** frame (relative to the post-Default pose, before bake), then recenter at geometry bounds. List those names in `orientation_names` to include them in the imaging pipeline.
+
+Names should be simple identifiers: letters, digits, underscores, and hyphens only (e.g. `Side`, `Left-view`). Avoid spaces, quotes, and backslashes—unusual characters can break YAML export/import round-trips.
 
 ### Verifying a load
 

--- a/traitblender/docs/configuration/config-files.md
+++ b/traitblender/docs/configuration/config-files.md
@@ -68,8 +68,20 @@ TraitBlender config files are **YAML** files that store the settings you see in 
 
 <p><strong>render</strong></p>
 <ul>
-  <li><code>engine</code>: <code>CYCLES</code> | Eevee (<code>BLENDER_EEVEE_NEXT</code> or <code>BLENDER_EEVEE</code>, depending on Blender version; YAML values are normalized on load) | <code>BLENDER_WORKBENCH</code></li>
-  <li><code>eevee_use_raytracing</code>: boolean</li>
+  <li><code>engine</code>: <code>CYCLES</code> | Eevee (<code>BLENDER_EEVEE</code> / <code>BLENDER_EEVEE_NEXT</code>; both accepted) | <code>BLENDER_WORKBENCH</code></li>
+  <li><code>cycles</code> (used when <code>engine</code> is <code>CYCLES</code>; written on export only for Cycles):
+    <ul>
+      <li><code>use_adaptive_sampling</code>, <code>adaptive_threshold</code>, <code>samples</code>, <code>adaptive_min_samples</code>, <code>time_limit</code>, <code>use_denoising</code> — final render sampling</li>
+      <li><code>use_preview_adaptive_sampling</code>, <code>preview_adaptive_threshold</code>, <code>preview_samples</code>, <code>preview_adaptive_min_samples</code>, <code>use_preview_denoising</code> — viewport sampling</li>
+    </ul>
+  </li>
+  <li><code>eevee</code> (used when engine is Eevee; written on export only for Eevee):
+    <ul>
+      <li><code>use_raytracing</code>: boolean</li>
+      <li><code>taa_render_samples</code>: integer (Samples)</li>
+    </ul>
+  </li>
+  <li>Legacy flat <code>eevee_use_raytracing</code> is still accepted on load</li>
 </ul>
 
 <p><strong>output</strong></p>
@@ -184,8 +196,18 @@ mat:
   roughness: 1.0
 
 render:
-  engine: BLENDER_EEVEE_NEXT  # or BLENDER_EEVEE on Blender 5.1+; both accepted in YAML
-  eevee_use_raytracing: false
+  engine: BLENDER_EEVEE  # or CYCLES / BLENDER_EEVEE_NEXT
+  eevee:
+    use_raytracing: false
+    taa_render_samples: 64
+  # When using Cycles, use a cycles: block instead, for example:
+  # engine: CYCLES
+  # cycles:
+  #   use_adaptive_sampling: true
+  #   adaptive_threshold: 0.01
+  #   samples: 4096
+  #   adaptive_min_samples: 0
+  #   time_limit: 0.0
 
 output:
   rendering_directory: ""   # The directory where simulation output will be written
@@ -358,8 +380,13 @@ mat:
   scale: [0.15, 0.15, 1.0]
 
 render:
-  eevee_use_raytracing: false
   engine: CYCLES
+  cycles:
+    use_adaptive_sampling: true
+    adaptive_threshold: 0.01
+    samples: 4096
+    adaptive_min_samples: 0
+    time_limit: 0.0
 
 output:
   image_format: PNG

--- a/traitblender/docs/configuration/config-files.md
+++ b/traitblender/docs/configuration/config-files.md
@@ -117,6 +117,7 @@ TraitBlender config files are **YAML** files that store the settings you see in 
 <p><strong>meshes</strong></p>
 <ul>
   <li><code>save_meshes</code>: boolean</li>
+  <li><code>orient_before_export</code>: boolean (default <code>true</code>). When saving meshes in the imaging pipeline, apply the morphospace <strong>Default</strong> orientation before export. Set to <code>false</code> to export the generated mesh as-is (recommended for ATLAS, where the SSM already provides a consistent PCA-aligned frame). Imaging orientations are still applied afterward for renders.</li>
   <li><code>file_export_type</code>: <code>obj</code> or <code>ply</code></li>
 </ul>
 
@@ -254,6 +255,7 @@ imaging:
 meshes:
   file_export_type: obj
   save_meshes: false
+  orient_before_export: true
 ```
 
  </details>
@@ -273,6 +275,8 @@ imaging:
 meshes:
   file_export_type: obj
   save_meshes: true
+  # ATLAS: keep SSM/PCA frame (skip Default table placement before export)
+  # orient_before_export: false
 ```
 
  </details>
@@ -436,6 +440,24 @@ transforms: []
 Under `imaging.custom_orientations`, map a unique name to Euler angles `[rx, ry, rz]` in **radians**. Built-in morphospace orientation names always win on collision. Customs are available for every morphospace: they run **Default**, apply the Euler in the specimen’s **local** frame (relative to the post-Default pose, before bake), then recenter at geometry bounds. List those names in `orientation_names` to include them in the imaging pipeline.
 
 Names should be simple identifiers: letters, digits, underscores, and hyphens only (e.g. `Side`, `Left-view`). Avoid spaces, quotes, and backslashes—unusual characters can break YAML export/import round-trips.
+
+### Mesh export in the imaging pipeline
+
+When `meshes.save_meshes` is `true`, the simulation pipeline writes one mesh per specimen under `rendering_directory/meshes/<specimen>/` **before** imaging orientations and transform randomization run for that specimen’s renders.
+
+`meshes.orient_before_export` (default `true`) controls the pose of that file:
+
+| Value | Mesh file contents |
+|-------|--------------------|
+| `true` (default) | Morphospace **Default** applied first (table placement). Same behavior as earlier TraitBlender releases. |
+| `false` | Export the mesh as generated, with no Default/table orientation. Prefer this for **ATLAS**, where the SSM already lives in a shared PCA-aligned frame. Imaging orientations still apply afterward for rendered images only. |
+
+```yaml
+meshes:
+  file_export_type: obj   # or ply
+  save_meshes: true
+  orient_before_export: false
+```
 
 ### Verifying a load
 

--- a/traitblender/docs/configuration/config-files.md
+++ b/traitblender/docs/configuration/config-files.md
@@ -110,7 +110,7 @@ TraitBlender config files are **YAML** files that store the settings you see in 
 <ul>
   <li><code>include_images</code>: boolean</li>
   <li><code>orientation_names</code>: list of strings (built-in and/or custom orientation names to include in the pipeline)</li>
-  <li><code>custom_orientations</code>: optional map of name → <code>[rx, ry, rz]</code> Euler angles in <strong>radians</strong>. Each custom orientation runs the morphospace Default, then applies the Euler in the specimen's <strong>local</strong> frame (relative to the post-Default pose, before bake), then recenters at geometry bounds. Available for all morphospaces; names must not collide with built-ins. Use simple keys: letters, digits, <code>_</code>, and <code>-</code> only (no spaces, quotes, or backslashes) so YAML export round-trips reliably.</li>
+  <li><code>custom_orientations</code>: optional map of name → <code>[rx, ry, rz]</code> Euler angles in <strong>radians</strong>. Each custom orientation runs the morphospace Default, then applies the Euler in the specimen's <strong>local</strong> frame (relative to the post-Default pose, before bake), then recenters at geometry bounds. Available for all morphospaces. Names must be unique identifiers (letters, digits, <code>_</code>, <code>-</code> only) and must not collide with built-ins or other customs; invalid YAML entries are skipped on load.</li>
   <li><code>images_per_orientation</code>: integer, ≥ 1</li>
 </ul>
 
@@ -439,7 +439,7 @@ transforms: []
 
 Under `imaging.custom_orientations`, map a unique name to Euler angles `[rx, ry, rz]` in **radians**. Built-in morphospace orientation names always win on collision. Customs are available for every morphospace: they run **Default**, apply the Euler in the specimen’s **local** frame (relative to the post-Default pose, before bake), then recenter at geometry bounds. List those names in `orientation_names` to include them in the imaging pipeline.
 
-Names should be simple identifiers: letters, digits, underscores, and hyphens only (e.g. `Side`, `Left-view`). Avoid spaces, quotes, and backslashes—unusual characters can break YAML export/import round-trips.
+Names must be simple identifiers: letters, digits, underscores, and hyphens only (e.g. `Side`, `Left-view`). Spaces, quotes, and other special characters are rejected in the UI, and names must not collide with another custom or a built-in orientation. Invalid entries in YAML are skipped on load.
 
 ### Mesh export in the imaging pipeline
 

--- a/traitblender/docs/configuration/config-files.md
+++ b/traitblender/docs/configuration/config-files.md
@@ -19,9 +19,11 @@ TraitBlender config files are **YAML** files that store the settings you see in 
   <li><code>metadata</code> – stamp text in the rendered images</li>
   <li><code>ruler</code> – ruler location / visibility</li>
   <li><code>transforms</code> – optional random variation on config values</li>
-  <li><code>imaging</code> – which orientations to render and how many images</li>
+  <li><code>imaging</code> – which orientations to render, custom Euler orientations, and how many images</li>
   <li><code>meshes</code> – mesh export options during simulation</li>
 </ul>
+
+<p>The Datasets panel <code>sample</code> controls (specimen location / rotation) are <strong>UI-only</strong>. A bare <code>sample:</code> key in YAML is ignored on load and is not written on export. See <a href="./unit-tests.md">Unit Tests</a> to verify a loaded file against the live scene.</p>
 
 <p><strong>Allowed values and ranges (quick reference)</strong></p>
 
@@ -425,4 +427,14 @@ transforms: []
 
 ## Using config files
 
-Use the GUI to export a YAML (recommended), then reuse it later by loading it back into the Configuration panel workflow.
+1. Export a YAML from the GUI (**Export Config as YAML**), or edit one by hand using the schema above.
+2. In **Museum Setup**, set **Config File** (or leave it empty and pick a file when prompted) and click **Configure Scene**.
+3. After a successful load, the chosen path is stored on `traitblender_setup.config_file` so the field and [unit tests](./unit-tests.md) stay in sync.
+
+### Custom orientations in YAML
+
+Under `imaging.custom_orientations`, map a unique name to Euler angles `[rx, ry, rz]` in **radians**. Built-in morphospace orientation names always win on collision. Customs are available for every morphospace: they run **Default**, apply the Euler in the specimen’s **local** frame (relative to the post-Default pose, before bake), then recenter at geometry bounds. List those names in `orientation_names` to include them in the imaging pipeline.
+
+### Verifying a load
+
+After Configure Scene, run `config_matches_scene` (see [Unit Tests](./unit-tests.md)) to confirm the YAML still matches the live scene—including Cycles/Eevee **render** vs **viewport** sampling keys.

--- a/traitblender/docs/configuration/config-files.md
+++ b/traitblender/docs/configuration/config-files.md
@@ -95,7 +95,8 @@ TraitBlender config files are **YAML** files that store the settings you see in 
 <p><strong>imaging</strong></p>
 <ul>
   <li><code>include_images</code>: boolean</li>
-  <li><code>orientation_names</code>: list of strings (orientation names from the selected morphospace)</li>
+  <li><code>orientation_names</code>: list of strings (built-in and/or custom orientation names to include in the pipeline)</li>
+  <li><code>custom_orientations</code>: optional map of name → <code>[rx, ry, rz]</code> Euler angles in <strong>radians</strong>. Each custom orientation runs the morphospace Default, then applies the Euler in the specimen's <strong>local</strong> frame (relative to the post-Default pose, before bake), then recenters at geometry bounds. Available for all morphospaces; names must not collide with built-ins.</li>
   <li><code>images_per_orientation</code>: integer, ≥ 1</li>
 </ul>
 
@@ -221,6 +222,10 @@ imaging:
   include_images: true
   orientation_names: []
   images_per_orientation: 1
+  # Optional named Euler orientations (radians), usable by any morphospace:
+  # custom_orientations:
+  #   Side: [1.5708, 0.0, 0.0]
+  #   Dorsal: [0.0, 1.5708, 0.0]
 
 meshes:
   file_export_type: obj
@@ -364,7 +369,9 @@ output:
 
 imaging:
   include_images: true
-  orientation_names: ['Default']
+  orientation_names: ['Default', 'Side']
+  custom_orientations:
+    Side: [1.5708, 0.0, 0.0]
   images_per_orientation: 1
 
 metadata:

--- a/traitblender/docs/configuration/unit-tests.md
+++ b/traitblender/docs/configuration/unit-tests.md
@@ -1,0 +1,65 @@
+# Unit Tests
+
+TraitBlender ships a small set of **in-addon unit tests** you can run from the Blender Python console (or headless scripts). They check that the live scene matches expectations after you configure it.
+
+## Running tests
+
+```python
+# List registered tests and their docstrings
+bpy.ops.traitblender.run_unit_test(test_name="help")
+
+# Run a specific test
+bpy.ops.traitblender.run_unit_test(test_name="config_matches_scene")
+```
+
+You can also call the registry directly:
+
+```python
+from bl_ext.user_default.traitblender.core.unit_test import run_test, list_tests, help_tests
+
+print(help_tests())
+result = run_test("config_matches_scene")
+print(result["passed"], result["message"])
+```
+
+Results are printed to the Blender console. The operator reports `PASS` or `FAIL` in the status bar; full mismatch details go to the console.
+
+## `config_matches_scene`
+
+Compares the YAML at `bpy.context.scene.traitblender_setup.config_file` to the live scene / TraitBlender config.
+
+**Prerequisites**
+
+1. Import the museum scene.
+2. Load a config with **Configure Scene** (or set `traitblender_setup.config_file` yourself, then configure).
+3. Run the test.
+
+If you use **Configure Scene** with an empty Config File field, the file browser path is written back to `config_file` after a successful load so the UI and this test share the same path.
+
+**What it checks**
+
+- Nested config sections present in the YAML (world, camera, lamp, mat, render, output, metadata, ruler, imaging, meshes, morphospace, transforms, dataset, …).
+- For `render.cycles` / `render.eevee`, values are compared against live Blender RNA (`scene.cycles` / `scene.eevee`), including final-render vs viewport sampling keys (`samples` vs `preview_samples`, etc.).
+- `render.engine` is normalized the same way Configure Scene applies it.
+
+**What it skips**
+
+- The UI-only `sample` section (bare `sample:` / `null` / `{}` in YAML is ignored on load and never counted as a mismatch).
+- Keys that are `null` or empty mappings at the root.
+- Fields not present in the YAML (omitted keys are not treated as “must equal default”).
+
+**Return value**
+
+```text
+{
+  "name": "config_matches_scene",
+  "passed": True | False,
+  "mismatches": [ {"path", "expected", "actual", "reason"}, ... ],
+  "message": "...",
+  "config_file": "..."
+}
+```
+
+## Adding tests
+
+Register new callables in `core/unit_test/__init__.py` under `TESTS`. Each test should accept an optional `context` and return a dict with at least `passed` and `message`.

--- a/traitblender/docs/configuration/unit-tests.md
+++ b/traitblender/docs/configuration/unit-tests.md
@@ -1,5 +1,7 @@
 # Unit Tests
 
+**This section is for TraitBlender developers.**
+
 TraitBlender ships a small set of **in-addon unit tests** you can run from the Blender Python console (or headless scripts). They check that the live scene matches expectations after you configure it.
 
 ## Running tests
@@ -26,7 +28,7 @@ Results are printed to the Blender console. The operator reports `PASS` or `FAIL
 
 ## `config_matches_scene`
 
-Compares the YAML at `bpy.context.scene.traitblender_setup.config_file` to the live scene / TraitBlender config.
+Compares the YAML at `bpy.context.scene.traitblender_setup.config_file` to the live scene and the TraitBlender config.
 
 **Prerequisites**
 
@@ -42,11 +44,6 @@ If you use **Configure Scene** with an empty Config File field, the file browser
 - For `render.cycles` / `render.eevee`, values are compared against live Blender RNA (`scene.cycles` / `scene.eevee`), including final-render vs viewport sampling keys (`samples` vs `preview_samples`, etc.).
 - `render.engine` is normalized the same way Configure Scene applies it.
 
-**What it skips**
-
-- The UI-only `sample` section (bare `sample:` / `null` / `{}` in YAML is ignored on load and never counted as a mismatch).
-- Keys that are `null` or empty mappings at the root.
-- Fields not present in the YAML (omitted keys are not treated as “must equal default”).
 
 **Return value**
 
@@ -62,4 +59,4 @@ If you use **Configure Scene** with an empty Config File field, the file browser
 
 ## Adding tests
 
-Register new callables in `core/unit_test/__init__.py` under `TESTS`. Each test should accept an optional `context` and return a dict with at least `passed` and `message`.
+Register new callables in `core/unit_test/__init__.py` under `TESTS`. Each test should accept an optional `context` and return a dict with at least `passed` and `message` (for developers).

--- a/traitblender/docs/documentation.md
+++ b/traitblender/docs/documentation.md
@@ -4,3 +4,5 @@ Choose your documentation path:
 
 - **[Quick Start (GUI)](./getting-started/quick-start.md)** - Main walkthrough for using TraitBlender in Blender
 - **[API Reference](./api/scene-assets.md)** - Operators and properties used in the GUI workflow
+- **[Configuration Files](./configuration/config-files.md)** - YAML schema, including imaging and custom orientations
+- **[Unit Tests](./configuration/unit-tests.md)** - Verify a loaded config still matches the live scene

--- a/traitblender/docs/getting-started/blender-optimization.md
+++ b/traitblender/docs/getting-started/blender-optimization.md
@@ -2,6 +2,7 @@
 
 Optimize your Blender setup for the best TraitBlender experience. These configuration changes will improve performance, enable useful features, and make your workflow smoother.
 
+<a id="python-tooltips"></a>
 ??? tip "Python Tooltips"
     Python tooltips show you the exact Python commands for UI operations, which is helpful when transitioning between GUI and API workflows.
 

--- a/traitblender/docs/getting-started/installation.md
+++ b/traitblender/docs/getting-started/installation.md
@@ -4,7 +4,7 @@
 
 | | |
 |--|--|
-| **TraitBlender** | **v2.3.0** |
+| **TraitBlender** | **v2.4.0** |
 | **Blender** | **5.1** and later |
 
 ??? note "System Requirements"
@@ -23,7 +23,7 @@
 
 You can install a downloaded release zip directly from the terminal:
 
-`blender --command extension install-file -r user_default --enable traitblender-v2.3.0-linux.zip`
+`blender --command extension install-file -r user_default --enable traitblender-v2.4.0-linux.zip`
 
 Use the zip that matches your OS:
 
@@ -46,7 +46,7 @@ After removing the extension, restart Blender. TraitBlender will no longer be av
 
 **Step 1: Download TraitBlender**
 
-- Download the latest release (**v2.3.0**) from [GitHub Releases](https://github.com/Imageomics/TraitBlender/releases)
+- Download the latest release (**v2.4.0**) from [GitHub Releases](https://github.com/Imageomics/TraitBlender/releases)
 - Save the `.zip` file to your computer
 
 **Step 2: Install in Blender**
@@ -75,7 +75,7 @@ To verify that TraitBlender is properly installed:
 
 **If something is wrong**
 
-- Use **Blender 5.1+** with **TraitBlender v2.3.0**
+- Use **Blender 5.1+** with **TraitBlender v2.4.0**
 - Check that the add-on is enabled in Preferences
 - Restart Blender completely
 

--- a/traitblender/docs/getting-started/quick-start.md
+++ b/traitblender/docs/getting-started/quick-start.md
@@ -125,7 +125,9 @@ Before starting, ensure you have:
 ??? note "Step 5: Orientations"
     Expand the **"5 Orientations"** panel.
 
-    Each morphospace can define orientation functions in its `ORIENTATIONS` dictionary. Select an orientation from the dropdown and click **Apply** to orient the specimen. The selected orientation is also applied automatically when running the Imaging Pipeline.
+    Each morphospace ships built-in orientation functions. Select one from the dropdown and click **Apply** to orient the specimen. **Default** is also applied automatically when you generate a sample or run the imaging pipeline.
+
+    You can add **custom orientations** in the same panel: give each a name and Euler angles `(rx, ry, rz)` in **radians**. Customs run Default first, then apply that Euler in the specimen's **local** frame (relative to the post-Default pose, before bake), then recenter at geometry bounds. They appear in the dropdown and in the Imaging panel checkboxes, and can be saved/loaded via YAML (`imaging.custom_orientations`).
 
 ??? note "Step 6: Transforms"
     Expand the **"6 Transforms"** panel.
@@ -151,7 +153,7 @@ Before starting, ensure you have:
 
     1. Use **Include Images** to control whether image files are rendered.
     2. Set the number of images per orientation if needed.
-    3. Choose which orientations are included for the imaging run.
+    3. Choose which orientations are included for the imaging run (built-ins and any custom orientations you defined).
 
 ??? note "Step 9: Simulation"
     Use the separate **Simulation** section below the numbered panels.

--- a/traitblender/docs/getting-started/quick-start.md
+++ b/traitblender/docs/getting-started/quick-start.md
@@ -25,6 +25,9 @@ Before starting, ensure you have:
     4. Press `0` on your numpad (or `0` with Emulate Numpad enabled) to switch to Camera View
     5. You should now be looking through the camera at the empty mat lying on the table
 
+    !!! note "Single scene"
+        TraitBlender assumes one active Blender scene (and its view layer). Operators, config, imaging sync, and orientations all use that active scene—multi-scene / multi-window setups are not supported. Keep your museum work in a single scene.
+
     ### Add a Ruler
 
     If the ruler object is missing or you need another copy, click **Add Ruler** in the **Museum Setup** panel. Each click appends a ruler from the museum scene and applies the ruler settings from your configuration (location, rotation, visibility). Blender assigns duplicate names automatically (e.g. `Ruler.001`).
@@ -130,6 +133,8 @@ Before starting, ensure you have:
     Each morphospace ships built-in orientation functions. Select one from the dropdown and click **Apply** to orient the specimen. **Default** is also applied automatically when you generate a sample or run the imaging pipeline.
 
     You can add **custom orientations** in the same panel: give each a name and Euler angles `(rx, ry, rz)` in **radians**. Customs run Default first, then apply that Euler in the specimen's **local** frame (relative to the post-Default pose, before bake), then recenter at geometry bounds. They appear in the dropdown and in the Imaging panel checkboxes, and can be saved/loaded via YAML (`imaging.custom_orientations`). Built-in names win if a custom name collides.
+
+    Use simple names: letters, digits, underscores, and hyphens only (e.g. `Side`, `Dorsal_01`). Avoid spaces, quotes, and backslashes so YAML export/import round-trips cleanly.
 
     Scripts and the imaging pipeline should apply orientations **by name** (`bpy.ops.traitblender.apply_orientation(orientation="...")`) so output folders match the pose that was used.
 

--- a/traitblender/docs/getting-started/quick-start.md
+++ b/traitblender/docs/getting-started/quick-start.md
@@ -6,7 +6,7 @@ Get up and running with TraitBlender's graphical interface in just a few minutes
 
 Before starting, ensure you have:
 
-- ✅ **Blender 5.1+** and **TraitBlender v2.3.0** ([supported versions](./installation.md#supported-versions))
+- ✅ **Blender 5.1+** and **TraitBlender v2.4.0** ([supported versions](./installation.md#supported-versions))
 - ✅ TraitBlender add-on installed ([Installation Guide](./installation.md))
 
 ??? note "Step 0: Enable TraitBlender"

--- a/traitblender/docs/getting-started/quick-start.md
+++ b/traitblender/docs/getting-started/quick-start.md
@@ -134,7 +134,7 @@ Before starting, ensure you have:
 
     You can add **custom orientations** in the same panel: give each a name and Euler angles `(rx, ry, rz)` in **radians**. Customs run Default first, then apply that Euler in the specimen's **local** frame (relative to the post-Default pose, before bake), then recenter at geometry bounds. They appear in the dropdown and in the Imaging panel checkboxes, and can be saved/loaded via YAML (`imaging.custom_orientations`). Built-in names win if a custom name collides.
 
-    Use simple names: letters, digits, underscores, and hyphens only (e.g. `Side`, `Dorsal_01`). Avoid spaces, quotes, and backslashes so YAML export/import round-trips cleanly.
+    Use simple names: letters, digits, underscores, and hyphens only (e.g. `Side`, `Dorsal_01`). Spaces, quotes, and other special characters are rejected, as are names that duplicate another custom or a built-in orientation.
 
     Scripts and the imaging pipeline should apply orientations **by name** (`bpy.ops.traitblender.apply_orientation(orientation="...")`) so output folders match the pose that was used.
 

--- a/traitblender/docs/getting-started/quick-start.md
+++ b/traitblender/docs/getting-started/quick-start.md
@@ -155,7 +155,8 @@ Before starting, ensure you have:
 
     1. Choose the mesh export type.
     2. Enable **Save Meshes** if you want the simulation pipeline to export meshes.
-    3. You can also use **Export Mesh** to save the current sample manually.
+    3. Optionally disable **Orient before export** to save meshes in the morphospace/SSM frame (recommended for ATLAS); leave it on (default) to apply Default table placement first.
+    4. You can also use **Export Mesh** to save the current sample manually.
 
 ??? note "Step 8: Imaging"
     Expand the **"8 Imaging"** panel.
@@ -171,10 +172,10 @@ Before starting, ensure you have:
     2. Click **Simulate Dataset**.
 
     The simulation pipeline will:
+    - Export meshes when enabled (optionally after Default if **Orient before export** is on; see Step 7)
     - Apply any configured transforms
     - Render from the current camera view
     - Save images when enabled
-    - Export meshes when enabled
     - Include metadata if configured
 
 ## Next Steps

--- a/traitblender/docs/getting-started/quick-start.md
+++ b/traitblender/docs/getting-started/quick-start.md
@@ -60,8 +60,10 @@ Before starting, ensure you have:
 
     ### Importing Configuration
 
-    1. In the **Museum Setup** panel, enter a path to a YAML config file in the **Config File** field
-    2. Click **Configure Scene** to load the configuration
+    1. In the **Museum Setup** panel, enter a path to a YAML config file in the **Config File** field (or leave it empty)
+    2. Click **Configure Scene** to load the configuration. If no path is set, a file browser opens; the path you pick is saved into **Config File** after a successful load
+
+    To confirm the YAML still matches the live scene afterward, see [Unit Tests](../configuration/unit-tests.md) (`config_matches_scene`).
 
     !!! warning "Scene Requirements"
         Configuration import only works if the museum scene has been loaded (via **Import Museum**). If you encounter issues, click **Clear Scene** and re-import the museum scene.
@@ -127,7 +129,9 @@ Before starting, ensure you have:
 
     Each morphospace ships built-in orientation functions. Select one from the dropdown and click **Apply** to orient the specimen. **Default** is also applied automatically when you generate a sample or run the imaging pipeline.
 
-    You can add **custom orientations** in the same panel: give each a name and Euler angles `(rx, ry, rz)` in **radians**. Customs run Default first, then apply that Euler in the specimen's **local** frame (relative to the post-Default pose, before bake), then recenter at geometry bounds. They appear in the dropdown and in the Imaging panel checkboxes, and can be saved/loaded via YAML (`imaging.custom_orientations`).
+    You can add **custom orientations** in the same panel: give each a name and Euler angles `(rx, ry, rz)` in **radians**. Customs run Default first, then apply that Euler in the specimen's **local** frame (relative to the post-Default pose, before bake), then recenter at geometry bounds. They appear in the dropdown and in the Imaging panel checkboxes, and can be saved/loaded via YAML (`imaging.custom_orientations`). Built-in names win if a custom name collides.
+
+    Scripts and the imaging pipeline should apply orientations **by name** (`bpy.ops.traitblender.apply_orientation(orientation="...")`) so output folders match the pose that was used.
 
 ??? note "Step 6: Transforms"
     Expand the **"6 Transforms"** panel.

--- a/traitblender/docs/index.md
+++ b/traitblender/docs/index.md
@@ -22,7 +22,7 @@ TraitBlender is a powerful Blender add-on designed for researchers and instituti
 <div align="center">
 <img src="./images/shell-specimen.png" alt="Museum-style shell specimen imaging with TraitBlender" width="540"/>
 <p><em>An example shell generated with TraitBlender, with added materials for styling.</em></p>
-<p><strong>TraitBlender v2.3.0</strong> · <strong>Blender 5.1+</strong>. See the <a href="getting-started/installation.md#supported-versions">installation guide</a>.</p>
+<p><strong>TraitBlender v2.4.0</strong> · <strong>Blender 5.1+</strong>. See the <a href="getting-started/installation.md#supported-versions">installation guide</a>.</p>
 </div>
 
 ---
@@ -70,7 +70,7 @@ If you use TraitBlender in your research, please cite my work:
           month        = jun,
           year         = 2026,
           publisher    = {Zenodo},
-          version      = {v2.3.0},
+          version      = {v2.4.0},
           doi          = {10.5281/zenodo.14804133},
           url          = {https://github.com/Imageomics/TraitBlender},
         }

--- a/traitblender/docs/index.md
+++ b/traitblender/docs/index.md
@@ -67,7 +67,7 @@ If you use TraitBlender in your research, please cite my work:
                           Porto, Arthur and
                           Uyeda, Josef C},
           title        = {TraitBlender},
-          month        = jun,
+          month        = jul,
           year         = 2026,
           publisher    = {Zenodo},
           version      = {v2.4.0},

--- a/traitblender/docs/morphospaces/atlas.md
+++ b/traitblender/docs/morphospaces/atlas.md
@@ -73,6 +73,18 @@ You can also define **custom Euler orientations** (any morphospace) in the Orien
 
 Select an orientation in the **Orientations** panel and click **Apply**, or include multiple orientations in the imaging pipeline.
 
+## Mesh export
+
+For 3D analysis, prefer exporting ATLAS meshes **without** Default table placement so they stay in the SSM/PCA frame:
+
+```yaml
+meshes:
+  save_meshes: true
+  orient_before_export: false
+```
+
+(`orient_before_export` defaults to `true` for backward compatibility with other morphospaces.) Imaging orientations still apply to rendered views. See [Configuration Files — Mesh export](../configuration/config-files.md#mesh-export-in-the-imaging-pipeline).
+
 ## References
 
 - Porto, A. (2025). ATLAS: Automated Template-based Landmark Alignment System. GitHub repository. https://github.com/agporto/ATLAS

--- a/traitblender/docs/morphospaces/atlas.md
+++ b/traitblender/docs/morphospaces/atlas.md
@@ -69,6 +69,8 @@ ATLAS defines many named orientations for multi-view imaging:
 - **Default** — specimen centered on the table (no rotation).
 - **X / Y / Z *n*/4 π Rotation** — rotations in π/4 steps about each axis (for comparable views across specimens).
 
+You can also define **custom Euler orientations** (any morphospace) in the Orientations panel or in YAML under `imaging.custom_orientations` (name → `[rx, ry, rz]` in radians). Customs run Default, apply the Euler in the specimen's **local** frame (relative to the post-Default pose, before bake), then recenter at geometry bounds.
+
 Select an orientation in the **Orientations** panel and click **Apply**, or include multiple orientations in the imaging pipeline.
 
 ## References

--- a/traitblender/docs/morphospaces/circle-grid.md
+++ b/traitblender/docs/morphospaces/circle-grid.md
@@ -31,3 +31,8 @@ diameter_0, diameter_1, ..., diameter_15
 ## Hyperparameters
 
 Circle Grid currently has **no extra hyperparameters** (`HYPERPARAMETERS = {}`), so you do not need a `hyperparams` block in the config for this morphospace.
+
+## Orientations
+
+Circle Grid includes built-in orientations (including **Default**). Custom Euler orientations from the Orientations panel / `imaging.custom_orientations` apply the same way as for other morphospaces — see [Morphospaces overview](overview.md#orientations).
+

--- a/traitblender/docs/morphospaces/overview.md
+++ b/traitblender/docs/morphospaces/overview.md
@@ -20,6 +20,6 @@ Built-in orientation functions live with each morphospace (always including **De
 2. Applies the Euler in the specimen’s **local** frame (relative to the post-Default pose, before bake)
 3. Recenters at geometry bounds
 
-Customs show up in the Apply dropdown and Imaging checkboxes, and persist via YAML (`imaging.custom_orientations`). Built-in names win if a custom name collides. Prefer simple names (letters, digits, `_`, `-`); avoid spaces, quotes, and backslashes so configs round-trip cleanly. See the [configuration reference](../configuration/config-files.md) and [API](../api/scene-assets.md).
+Customs show up in the Apply dropdown and Imaging checkboxes, and persist via YAML (`imaging.custom_orientations`). Built-in names win if a custom name would collide—the UI and YAML load reject duplicates and non-identifier names (letters, digits, `_`, `-` only). See the [configuration reference](../configuration/config-files.md) and [API](../api/scene-assets.md).
 
 Follow the links above for the full list of parameters, default values, and ranges that make sense in practice.

--- a/traitblender/docs/morphospaces/overview.md
+++ b/traitblender/docs/morphospaces/overview.md
@@ -20,6 +20,6 @@ Built-in orientation functions live with each morphospace (always including **De
 2. Applies the Euler in the specimen’s **local** frame (relative to the post-Default pose, before bake)
 3. Recenters at geometry bounds
 
-Customs show up in the Apply dropdown and Imaging checkboxes, and persist via YAML (`imaging.custom_orientations`). Built-in names win if a custom name collides. See the [configuration reference](../configuration/config-files.md) and [API](../api/scene-assets.md).
+Customs show up in the Apply dropdown and Imaging checkboxes, and persist via YAML (`imaging.custom_orientations`). Built-in names win if a custom name collides. Prefer simple names (letters, digits, `_`, `-`); avoid spaces, quotes, and backslashes so configs round-trip cleanly. See the [configuration reference](../configuration/config-files.md) and [API](../api/scene-assets.md).
 
 Follow the links above for the full list of parameters, default values, and ranges that make sense in practice.

--- a/traitblender/docs/morphospaces/overview.md
+++ b/traitblender/docs/morphospaces/overview.md
@@ -10,5 +10,16 @@ Each morphospace has a **name** (e.g. "Shell (Default)", "Circle Grid", "ATLAS")
 
 - **traits** – columns in the dataset (per-specimen values)
 - **hyperparameters** – extra settings that affect how the model is generated (set in the Configuration panel)
+- **orientations** – named poses for the specimen on the table (built-in per morphospace, plus optional custom Eulers)
+
+## Orientations
+
+Built-in orientation functions live with each morphospace (always including **Default**). In the **Orientations** panel you can also add **custom orientations**: a name plus Euler `(rx, ry, rz)` in radians. For any morphospace, a custom orientation:
+
+1. Runs **Default**
+2. Applies the Euler in the specimen’s **local** frame (relative to the post-Default pose, before bake)
+3. Recenters at geometry bounds
+
+Customs show up in the Apply dropdown and Imaging checkboxes, and persist via YAML (`imaging.custom_orientations`). Built-in names win if a custom name collides. See the [configuration reference](../configuration/config-files.md) and [API](../api/scene-assets.md).
 
 Follow the links above for the full list of parameters, default values, and ranges that make sense in practice.

--- a/traitblender/docs/morphospaces/shell.md
+++ b/traitblender/docs/morphospaces/shell.md
@@ -73,6 +73,10 @@ morphospace:
     use_inner_surface: true
 ```
 
+## Orientations
+
+Shell defines built-in named orientations (including **Default**) for placing specimens on the table. You can also define **custom Euler orientations** that work with Shell (and every other morphospace) in the Orientations panel or under `imaging.custom_orientations` in YAML — see [Morphospaces overview](overview.md#orientations) and [Configuration Files](../configuration/config-files.md).
+
 ## References
 
 - Contreras-Figueroa, R. & Aragón, L. (2023). A mathematical model for mollusc shells based on parametric surfaces and the application to *Conus* shells. *Diversity* **15**, 431. [https://doi.org/10.3390/d15030431](https://doi.org/10.3390/d15030431)

--- a/traitblender/mkdocs.yml
+++ b/traitblender/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - Operators and Properties: api/scene-assets.md
     - Configuration:
       - Configuration Files: configuration/config-files.md
+      - Unit Tests: configuration/unit-tests.md
   - Morphospaces:
     - Overview: morphospaces/overview.md
     - Shell (Default): morphospaces/shell.md

--- a/traitblender/ui/operators/__init__.py
+++ b/traitblender/ui/operators/__init__.py
@@ -22,6 +22,7 @@ from . import (
     generate_morphospace_sample_op,
     imaging_pipeline_op,
     apply_orientation_op,
+    custom_orientation_ops,
     render_image_op,
 )
 
@@ -56,6 +57,8 @@ classes = [
     generate_morphospace_sample_op.TRAITBLENDER_OT_generate_morphospace_sample,
     imaging_pipeline_op.TRAITBLENDER_OT_imaging_pipeline,
     apply_orientation_op.TRAITBLENDER_OT_apply_orientation,
+    custom_orientation_ops.TRAITBLENDER_OT_add_custom_orientation,
+    custom_orientation_ops.TRAITBLENDER_OT_remove_custom_orientation,
     render_image_op.TRAITBLENDER_OT_render_image,
 ]
 

--- a/traitblender/ui/operators/__init__.py
+++ b/traitblender/ui/operators/__init__.py
@@ -24,6 +24,7 @@ from . import (
     apply_orientation_op,
     custom_orientation_ops,
     render_image_op,
+    unit_test,
 )
 
 _dpg_operator_classes = []
@@ -60,6 +61,7 @@ classes = [
     custom_orientation_ops.TRAITBLENDER_OT_add_custom_orientation,
     custom_orientation_ops.TRAITBLENDER_OT_remove_custom_orientation,
     render_image_op.TRAITBLENDER_OT_render_image,
+    unit_test.TRAITBLENDER_OT_run_unit_test,
 ]
 
 

--- a/traitblender/ui/operators/apply_orientation_op.py
+++ b/traitblender/ui/operators/apply_orientation_op.py
@@ -1,16 +1,15 @@
 """
 TraitBlender Apply Orientation Operator
 
-Applies the selected orientation function from the morphospace's ORIENTATIONS dict
-to the current sample object. Resets to rest state (from traitblender_sample) first,
-then applies the orientation and bakes rotation.
+Applies a named orientation from the morphospace ORIENTATIONS merge (built-ins +
+customs) via the shared core helper. Optional ``orientation`` property overrides
+the UI enum so callers (e.g. imaging pipeline) never rely on enum state for naming.
 """
 
 import bpy
 from bpy.types import Operator
-from mathutils import Euler
-from ...core.morphospaces import get_orientations_for_morphospace
-from ...core.helpers import bake_rotation_to_mesh
+from bpy.props import StringProperty
+from ...core.morphospaces import apply_orientation_by_name
 
 
 class TRAITBLENDER_OT_apply_orientation(Operator):
@@ -21,66 +20,37 @@ class TRAITBLENDER_OT_apply_orientation(Operator):
     bl_description = "Apply the selected orientation function to the specimen"
     bl_options = {'REGISTER', 'UNDO'}
 
+    orientation: StringProperty(
+        name="Orientation",
+        description="Orientation name to apply; empty uses the Orientations panel selection",
+        default="",
+    )
+
     def execute(self, context):
-        dataset = context.scene.traitblender_dataset
-        setup = context.scene.traitblender_setup
-
-        if not dataset.sample:
-            self.report({'ERROR'}, "No sample selected in dataset")
-            return {'CANCELLED'}
-
-        sample_name = dataset.sample
-        if sample_name not in bpy.data.objects:
-            self.report({'ERROR'}, f"Sample object '{sample_name}' not found in scene")
-            return {'CANCELLED'}
-
-        orientation_key = context.scene.traitblender_orientation.orientation
-        orientations = get_orientations_for_morphospace(setup.available_morphospaces)
-        if not orientation_key or orientation_key not in orientations:
-            return {'FINISHED'}  # No orientation to apply
-
-        orient_func = orientations[orientation_key]
-        if not callable(orient_func):
-            self.report({'ERROR'}, f"Orientation '{orientation_key}' is not callable")
-            return {'CANCELLED'}
-
-        sample_obj = bpy.data.objects[sample_name]
-        scene = context.scene
-        sample_data = scene.traitblender_sample
+        orientation_key = (self.orientation or "").strip()
+        if not orientation_key:
+            orientation_key = context.scene.traitblender_orientation.orientation
 
         try:
-            # Reset to rest state (as when sample was created) before applying orientation
-            if bpy.context.mode != 'OBJECT':
-                bpy.ops.object.mode_set(mode='OBJECT')
-            bpy.ops.object.select_all(action='DESELECT')
-            sample_obj.select_set(True)
-            bpy.context.view_layer.objects.active = sample_obj
-
-            last_baked = sample_data.last_baked_rotation
-            if (last_baked[0], last_baked[1], last_baked[2]) != (0.0, 0.0, 0.0):
-                # Use rotation matrix inverse so Flipped (and any combined rotation) undoes correctly
-                eul = Euler(last_baked)
-                inv_rot = eul.to_matrix().inverted()
-                sample_obj.rotation_euler = inv_rot.to_euler(eul.order)
-                bpy.ops.object.transform_apply(rotation=True)
-                sample_data.last_baked_rotation = (0.0, 0.0, 0.0)
-
-            # Restore baseline rotation (do NOT change origin or location here)
-            sample_obj.rotation_euler = Euler(sample_data.rest_rotation)
-            bpy.context.view_layer.update()
-
-            orient_func(sample_obj)
-            bpy.context.view_layer.update()
-
-            sample_data.last_baked_rotation = tuple(sample_obj.rotation_euler)
-            bake_rotation_to_mesh(sample_name)
-            # Ensure origin is always the geometry bounds center (not world origin)
-            bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY', center='BOUNDS')
-            bpy.context.view_layer.update()
-
-            self.report({'INFO'}, f"Applied orientation: {orientation_key}")
+            applied = apply_orientation_by_name(context, orientation_key)
+        except ValueError as e:
+            msg = str(e)
+            # Quiet no-op when nothing is selected / orientation unavailable in UI
+            if msg in (
+                "No orientation name provided",
+            ) or msg.startswith("Orientation '") and " not found for morphospace " in msg:
+                return {'FINISHED'}
+            self.report({'ERROR'}, msg)
+            return {'CANCELLED'}
         except Exception as e:
-            self.report({'ERROR'}, f"Failed to apply orientation: {str(e)}")
+            self.report({'ERROR'}, f"Failed to apply orientation: {e}")
             return {'CANCELLED'}
 
+        # Keep UI enum in sync when possible (best-effort; apply does not depend on it)
+        try:
+            context.scene.traitblender_orientation.orientation = applied
+        except Exception:
+            pass
+
+        self.report({'INFO'}, f"Applied orientation: {applied}")
         return {'FINISHED'}

--- a/traitblender/ui/operators/apply_orientation_op.py
+++ b/traitblender/ui/operators/apply_orientation_op.py
@@ -27,18 +27,21 @@ class TRAITBLENDER_OT_apply_orientation(Operator):
     )
 
     def execute(self, context):
-        orientation_key = (self.orientation or "").strip()
-        if not orientation_key:
-            orientation_key = context.scene.traitblender_orientation.orientation
+        explicit = (self.orientation or "").strip()
+        orientation_key = explicit or context.scene.traitblender_orientation.orientation
 
         try:
             applied = apply_orientation_by_name(context, orientation_key)
         except ValueError as e:
             msg = str(e)
-            # Quiet no-op when nothing is selected / orientation unavailable in UI
-            if msg in (
-                "No orientation name provided",
-            ) or msg.startswith("Orientation '") and " not found for morphospace " in msg:
+            # Quiet no-op only when relying on the UI enum (no explicit argument)
+            if not explicit and (
+                msg == "No orientation name provided"
+                or (
+                    msg.startswith("Orientation '")
+                    and " not found for morphospace " in msg
+                )
+            ):
                 return {'FINISHED'}
             self.report({'ERROR'}, msg)
             return {'CANCELLED'}

--- a/traitblender/ui/operators/config_ops.py
+++ b/traitblender/ui/operators/config_ops.py
@@ -4,6 +4,46 @@ import os
 from bpy.types import Operator
 from bpy.props import StringProperty
 from ...core.datasets.traitblender_dataset import update_filepath, _normalize_dataset_path
+from ...core.helpers.render_engine_compat import (
+    normalize_render_engine_value,
+    try_set_render_engine,
+)
+
+
+def _apply_render_engine_from_config(context, config_data):
+    """
+    Force-apply render.engine from YAML after the rest of config load.
+
+    Returns (wanted, actual) or None if YAML has no render.engine.
+    """
+    render = config_data.get("render")
+    if not isinstance(render, dict) or "engine" not in render:
+        return None
+
+    raw = render["engine"]
+    wanted = normalize_render_engine_value(raw)
+    scene = context.scene
+    try:
+        actual = try_set_render_engine(scene, raw)
+    except Exception as e:
+        print(f"TraitBlender: Failed to set render.engine from YAML {raw!r}: {e}")
+        return wanted, scene.render.engine
+
+    context.view_layer.update()
+    if hasattr(context, "window_manager"):
+        for window in context.window_manager.windows:
+            screen = window.screen
+            if screen is None:
+                continue
+            for area in screen.areas:
+                area.tag_redraw()
+
+    actual = scene.render.engine
+    print(
+        f"TraitBlender: Configure Scene render.engine "
+        f"yaml={raw!r} wanted={wanted!r} actual={actual!r}"
+    )
+    return wanted, actual
 
 
 class TRAITBLENDER_OT_configure_scene(Operator):
@@ -12,7 +52,8 @@ class TRAITBLENDER_OT_configure_scene(Operator):
     bl_idname = "traitblender.configure_scene"
     bl_label = "Configure Scene"
     bl_description = "Load and apply configuration from YAML file"
-    bl_options = {'REGISTER', 'UNDO'}
+    # No UNDO: a full YAML apply must not be partially reverted by the undo stack
+    bl_options = {'REGISTER'}
     
     filepath: StringProperty(
         name="Config File Path",
@@ -47,6 +88,42 @@ class TRAITBLENDER_OT_configure_scene(Operator):
             # Apply the configuration using the from_dict method
             context.scene.traitblender_config.from_dict(config_data)
 
+            # Force render.engine last so nothing else in from_dict can leave it stale.
+            engine_result = _apply_render_engine_from_config(context, config_data)
+            if engine_result is not None:
+                wanted, actual = engine_result
+                if actual != wanted:
+                    self.report(
+                        {'WARNING'},
+                        f"Render engine YAML asked for {wanted} but scene is {actual}",
+                    )
+
+            # Final imaging sync after morphospace + customs are both loaded.
+            # Default policy: only "Default" enabled unless YAML lists orientation_names.
+            imaging = context.scene.traitblender_config.imaging
+            enabled = {"Default"}
+            if isinstance(config_data.get("imaging"), dict):
+                names = config_data["imaging"].get("orientation_names")
+                if isinstance(names, list):
+                    enabled = {n for n in names if isinstance(n, str)}
+            try:
+                imaging.sync_orientation_options(context, enabled_names=enabled)
+            except Exception as e:
+                print(f"TraitBlender: Post-configure orientation sync failed: {e}")
+
+            missing = [
+                name
+                for name in ("Camera", "Mat", "Lamp")
+                if name not in bpy.data.objects
+            ]
+            if missing:
+                self.report(
+                    {'WARNING'},
+                    "Museum objects missing ("
+                    + ", ".join(missing)
+                    + "); run Import Museum first so those settings can apply.",
+                )
+
             # Force an explicit dataset import after config load.
             # Do not rely on property update callbacks here; they may not run when
             # the value is unchanged, and users expect Configure Scene to load data.
@@ -61,7 +138,15 @@ class TRAITBLENDER_OT_configure_scene(Operator):
                     if not (dataset.csv or "").strip():
                         self.report({'WARNING'}, f"Dataset path set but CSV is empty after import: {p}")
             
-            self.report({'INFO'}, f"Configuration loaded successfully from {config_file_path}")
+            self.report(
+                {'INFO'},
+                f"Configuration loaded from {config_file_path}"
+                + (
+                    f" (render.engine={context.scene.render.engine})"
+                    if engine_result is not None
+                    else ""
+                ),
+            )
             return {'FINISHED'}
             
         except yaml.YAMLError as e:

--- a/traitblender/ui/operators/config_ops.py
+++ b/traitblender/ui/operators/config_ops.py
@@ -71,6 +71,8 @@ class TRAITBLENDER_OT_configure_scene(Operator):
         if not config_file_path:
             self.report({'ERROR'}, "No configuration file specified")
             return {'CANCELLED'}
+
+        config_file_path = os.path.abspath(os.path.expanduser(config_file_path))
         
         if not os.path.exists(config_file_path):
             self.report({'ERROR'}, f"Configuration file not found: {config_file_path}")
@@ -84,6 +86,10 @@ class TRAITBLENDER_OT_configure_scene(Operator):
             if not config_data:
                 self.report({'ERROR'}, "Configuration file is empty or invalid")
                 return {'CANCELLED'}
+
+            # Persist path so the UI field and config_matches_scene test see it
+            # (file-browser invoke only sets the operator filepath, not setup.config_file).
+            context.scene.traitblender_setup.config_file = config_file_path
             
             # Apply the configuration using the from_dict method
             context.scene.traitblender_config.from_dict(config_data)

--- a/traitblender/ui/operators/custom_orientation_ops.py
+++ b/traitblender/ui/operators/custom_orientation_ops.py
@@ -6,15 +6,7 @@ import bpy
 from bpy.types import Operator
 from bpy.props import IntProperty
 
-
-def _unique_custom_name(imaging, base="Custom"):
-    existing = {(item.name or "").strip() for item in imaging.custom_orientations}
-    if base not in existing:
-        return base
-    i = 1
-    while f"{base}.{i:03d}" in existing:
-        i += 1
-    return f"{base}.{i:03d}"
+from ...core.helpers.orientation_helpers import unique_custom_orientation_name
 
 
 class TRAITBLENDER_OT_add_custom_orientation(Operator):
@@ -22,14 +14,29 @@ class TRAITBLENDER_OT_add_custom_orientation(Operator):
 
     bl_idname = "traitblender.add_custom_orientation"
     bl_label = "Add Custom Orientation"
-    bl_description = "Add a custom local Euler orientation (radians) available for all morphospaces"
+    bl_description = (
+        "Add a custom local Euler orientation (radians). "
+        "Names must be unique and use only letters, digits, underscores, and hyphens"
+    )
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
         imaging = context.scene.traitblender_config.imaging
+        morphospace_name = context.scene.traitblender_setup.available_morphospaces
         item = imaging.custom_orientations.add()
-        item.name = _unique_custom_name(imaging)
+        idx = len(imaging.custom_orientations) - 1
+        name = unique_custom_orientation_name(
+            imaging,
+            morphospace_name=morphospace_name,
+            exclude_index=idx,
+        )
+        item.validated_name = name
+        item.name = name
         item.rotation = (0.0, 0.0, 0.0)
+        try:
+            imaging.sync_orientation_options(context, enabled_names=None)
+        except Exception as e:
+            print(f"TraitBlender: Imaging orientation sync after add failed: {e}")
         self.report({'INFO'}, f"Added custom orientation: {item.name}")
         return {'FINISHED'}
 
@@ -51,10 +58,9 @@ class TRAITBLENDER_OT_remove_custom_orientation(Operator):
             return {'CANCELLED'}
         name = imaging.custom_orientations[self.index].name
         imaging.custom_orientations.remove(self.index)
-        # Drop pipeline checkbox entry if present
-        for i, opt in enumerate(list(imaging.orientation_options)):
-            if opt.name == name:
-                imaging.orientation_options.remove(i)
-                break
+        try:
+            imaging.sync_orientation_options(context, enabled_names=None)
+        except Exception as e:
+            print(f"TraitBlender: Imaging orientation sync after remove failed: {e}")
         self.report({'INFO'}, f"Removed custom orientation: {name}")
         return {'FINISHED'}

--- a/traitblender/ui/operators/custom_orientation_ops.py
+++ b/traitblender/ui/operators/custom_orientation_ops.py
@@ -1,0 +1,60 @@
+"""
+Operators for adding/removing custom Euler orientations on imaging config.
+"""
+
+import bpy
+from bpy.types import Operator
+from bpy.props import IntProperty
+
+
+def _unique_custom_name(imaging, base="Custom"):
+    existing = {(item.name or "").strip() for item in imaging.custom_orientations}
+    if base not in existing:
+        return base
+    i = 1
+    while f"{base}.{i:03d}" in existing:
+        i += 1
+    return f"{base}.{i:03d}"
+
+
+class TRAITBLENDER_OT_add_custom_orientation(Operator):
+    """Add a named custom Euler orientation"""
+
+    bl_idname = "traitblender.add_custom_orientation"
+    bl_label = "Add Custom Orientation"
+    bl_description = "Add a custom local Euler orientation (radians) available for all morphospaces"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        imaging = context.scene.traitblender_config.imaging
+        item = imaging.custom_orientations.add()
+        item.name = _unique_custom_name(imaging)
+        item.rotation = (0.0, 0.0, 0.0)
+        self.report({'INFO'}, f"Added custom orientation: {item.name}")
+        return {'FINISHED'}
+
+
+class TRAITBLENDER_OT_remove_custom_orientation(Operator):
+    """Remove a custom Euler orientation by index"""
+
+    bl_idname = "traitblender.remove_custom_orientation"
+    bl_label = "Remove Custom Orientation"
+    bl_description = "Remove this custom orientation"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    index: IntProperty(name="Index", default=0, min=0)
+
+    def execute(self, context):
+        imaging = context.scene.traitblender_config.imaging
+        if self.index < 0 or self.index >= len(imaging.custom_orientations):
+            self.report({'ERROR'}, "Invalid custom orientation index")
+            return {'CANCELLED'}
+        name = imaging.custom_orientations[self.index].name
+        imaging.custom_orientations.remove(self.index)
+        # Drop pipeline checkbox entry if present
+        for i, opt in enumerate(list(imaging.orientation_options)):
+            if opt.name == name:
+                imaging.orientation_options.remove(i)
+                break
+        self.report({'INFO'}, f"Removed custom orientation: {name}")
+        return {'FINISHED'}

--- a/traitblender/ui/operators/generate_morphospace_sample_op.py
+++ b/traitblender/ui/operators/generate_morphospace_sample_op.py
@@ -127,7 +127,7 @@ class TRAITBLENDER_OT_generate_morphospace_sample(Operator):
                         print(f"Set orientation to: {bpy.context.scene.traitblender_orientation.orientation}")
                     except Exception as e:
                         traceback.print_exc()
-                        self.report({'Error'}, f"Failed to set orientation: {e}")
+                        self.report({'ERROR'}, f"Failed to set orientation: {e}")
                         return {'CANCELLED'}
 
                     try:
@@ -135,7 +135,7 @@ class TRAITBLENDER_OT_generate_morphospace_sample(Operator):
                         print(f"Successfully applied orientation: {bpy.context.scene.traitblender_orientation.orientation}")
                     except Exception as e:
                         traceback.print_exc()
-                        self.report({'Error'}, f"Failed to apply orientation: {e}")
+                        self.report({'ERROR'}, f"Failed to apply orientation: {e}")
                         return {'CANCELLED'}
 
                     if "Table" not in bpy.data.objects:

--- a/traitblender/ui/operators/generate_morphospace_sample_op.py
+++ b/traitblender/ui/operators/generate_morphospace_sample_op.py
@@ -1,5 +1,6 @@
 import bpy
 from bpy.types import Operator
+from bpy.props import BoolProperty
 import inspect
 from ...core.morphospaces import load_morphospace_module
 import traceback
@@ -12,6 +13,16 @@ class TRAITBLENDER_OT_generate_morphospace_sample(Operator):
     bl_label = "Generate Morphospace Sample"
     bl_description = "Generate a morphospace sample using selected morphospace and dataset row"
     bl_options = {'REGISTER', 'UNDO'}
+
+    apply_default_orientation: BoolProperty(
+        name="Apply Default Orientation",
+        description=(
+            "Apply the morphospace Default orientation after generation. "
+            "Disable when the imaging pipeline will export an unoriented mesh first"
+        ),
+        default=True,
+        options={'SKIP_SAVE'},
+    )
 
     def execute(self, context):
         setup = context.scene.traitblender_setup
@@ -110,24 +121,25 @@ class TRAITBLENDER_OT_generate_morphospace_sample(Operator):
                 scene.traitblender_sample.rest_rotation = tuple(generated_obj.rotation_euler)
                 scene.traitblender_sample.last_baked_rotation = (0.0, 0.0, 0.0)
 
-                try:
-                    bpy.context.scene.traitblender_orientation.orientation = 'Default'
-                    print(f"Set orientation to: {bpy.context.scene.traitblender_orientation.orientation}")
-                except Exception as e:
-                    traceback.print_exc()
-                    self.report({'Error'}, f"Failed to set orientation: {e}")
-                    return {'CANCELLED'}
+                if self.apply_default_orientation:
+                    try:
+                        bpy.context.scene.traitblender_orientation.orientation = 'Default'
+                        print(f"Set orientation to: {bpy.context.scene.traitblender_orientation.orientation}")
+                    except Exception as e:
+                        traceback.print_exc()
+                        self.report({'Error'}, f"Failed to set orientation: {e}")
+                        return {'CANCELLED'}
 
-                try:
-                    bpy.ops.traitblender.apply_orientation()
-                    print(f"Successfully applied orientation: {bpy.context.scene.traitblender_orientation.orientation}")        
-                except Exception as e:
-                    traceback.print_exc()
-                    self.report({'Error'}, f"Failed to apply orientation: {e}")
-                    return {'CANCELLED'}
+                    try:
+                        bpy.ops.traitblender.apply_orientation()
+                        print(f"Successfully applied orientation: {bpy.context.scene.traitblender_orientation.orientation}")
+                    except Exception as e:
+                        traceback.print_exc()
+                        self.report({'Error'}, f"Failed to apply orientation: {e}")
+                        return {'CANCELLED'}
 
-                if "Table" not in bpy.data.objects:
-                    self.report({'WARNING'}, "Table object missing - run Import Museum first for correct orientation")
+                    if "Table" not in bpy.data.objects:
+                        self.report({'WARNING'}, "Table object missing - run Import Museum first for correct orientation")
               
                 bpy.context.view_layer.update()
 

--- a/traitblender/ui/operators/imaging_pipeline_op.py
+++ b/traitblender/ui/operators/imaging_pipeline_op.py
@@ -47,6 +47,7 @@ class TRAITBLENDER_OT_imaging_pipeline(Operator):
     _include_images = True
     _render_dir = ""
     _save_meshes = False
+    _orient_before_export = True
     _mesh_root = ""
     _exported_mesh_for_specimen = False
     _mesh_path = ""
@@ -78,16 +79,22 @@ class TRAITBLENDER_OT_imaging_pipeline(Operator):
                     bpy.data.objects.remove(prev_obj, do_unlink=True)
 
             dataset.sample = name
-            bpy.ops.traitblender.generate_morphospace_sample()
+            # When exporting unoriented meshes, skip Default on generate so the file
+            # matches the morphospace/SSM frame (e.g. ATLAS PCA alignment).
+            apply_default = (not self._save_meshes) or self._orient_before_export
+            bpy.ops.traitblender.generate_morphospace_sample(
+                apply_default_orientation=apply_default
+            )
             self._exported_mesh_for_specimen = False
             self._mesh_path = ""
             self._last_applied_orientation = ""
 
-            # Optional mesh export: once per specimen, at Default orientation only
+            # Optional mesh export: once per specimen, before imaging orientations/transforms
             if self._save_meshes and not self._exported_mesh_for_specimen:
                 try:
-                    apply_orientation_by_name(context, "Default", sample_name=name)
-                    self._last_applied_orientation = "Default"
+                    if self._orient_before_export:
+                        apply_orientation_by_name(context, "Default", sample_name=name)
+                        self._last_applied_orientation = "Default"
                     mesh_dir = os.path.join(self._mesh_root, name)
                     os.makedirs(mesh_dir, exist_ok=True)
                     self._mesh_path = os.path.join(mesh_dir, f"{name}")
@@ -130,7 +137,8 @@ class TRAITBLENDER_OT_imaging_pipeline(Operator):
 
         # Directory structure:
         # - Always: render_dir / images / specimen_name / orientation_sanitized /
-        # - If save_meshes: render_dir / meshes / specimen_name / (one model at Default only)
+        # - If save_meshes: render_dir / meshes / specimen_name /
+        #   (Default-oriented if meshes.orient_before_export, else as generated)
         orient_subdir = _sanitize_orientation_for_path(orientation_name)
         images_dir = os.path.join(self._render_dir, "images", name, orient_subdir)
         # Keep configs under images when meshes are enabled so the dataset root splits into images/ + meshes/
@@ -222,6 +230,9 @@ class TRAITBLENDER_OT_imaging_pipeline(Operator):
         self._images_per_orientation = config.imaging.images_per_orientation
         self._render_dir = render_dir
         self._save_meshes = bool(getattr(config.meshes, "save_meshes", False))
+        self._orient_before_export = bool(
+            getattr(config.meshes, "orient_before_export", True)
+        )
         self._mesh_root = os.path.join(render_dir, "meshes")
         self._specimen_idx = 0
         self._orientation_idx = 0

--- a/traitblender/ui/operators/imaging_pipeline_op.py
+++ b/traitblender/ui/operators/imaging_pipeline_op.py
@@ -5,7 +5,7 @@ import re
 import csv
 from datetime import datetime
 
-from ...core.morphospaces import get_orientation_names
+from ...core.morphospaces import get_orientation_names, apply_orientation_by_name
 from ...core.meshes import export_current_sample
 
 
@@ -13,6 +13,21 @@ def _sanitize_orientation_for_path(name):
     """Make orientation name safe for directory/file names."""
     s = name.replace(" ", "_").replace(",", "")
     return re.sub(r"[^\w\-]", "", s) or "orientation"
+
+
+def _enabled_orientation_names(context, morphospace_name):
+    """
+    Build the imaging orientation list from one source of truth.
+
+    Order and identity come from ``get_orientation_names`` (same dict used to apply).
+    Enablement comes from imaging.orientation_options checkboxes keyed by that name.
+    """
+    names = get_orientation_names(morphospace_name, context) if morphospace_name else []
+    if not names:
+        return []
+    options = context.scene.traitblender_config.imaging.orientation_options
+    enabled = {item.name: bool(item.enabled) for item in options}
+    return [n for n in names if enabled.get(n, False)]
 
 
 class TRAITBLENDER_OT_imaging_pipeline(Operator):
@@ -71,8 +86,8 @@ class TRAITBLENDER_OT_imaging_pipeline(Operator):
             # Optional mesh export: once per specimen, at Default orientation only
             if self._save_meshes and not self._exported_mesh_for_specimen:
                 try:
-                    context.scene.traitblender_orientation.orientation = "Default"
-                    bpy.ops.traitblender.apply_orientation()
+                    apply_orientation_by_name(context, "Default", sample_name=name)
+                    self._last_applied_orientation = "Default"
                     mesh_dir = os.path.join(self._mesh_root, name)
                     os.makedirs(mesh_dir, exist_ok=True)
                     self._mesh_path = os.path.join(mesh_dir, f"{name}")
@@ -85,16 +100,18 @@ class TRAITBLENDER_OT_imaging_pipeline(Operator):
                     # Don't crash the imaging pipeline if mesh export fails
                     print(f"TraitBlender: Mesh export failed for '{name}': {e}")
 
-        # Set and apply this orientation at start of each orientation block
-        current_ui_orientation = getattr(context.scene.traitblender_orientation, "orientation", "")
+        # Apply this orientation by name (same string used for folders / CSV / logs)
         if (
             self._img_idx == 0
-            or current_ui_orientation != orientation_name
             or self._last_applied_orientation != orientation_name
         ):
-            context.scene.traitblender_orientation.orientation = orientation_name
-            bpy.ops.traitblender.apply_orientation()
+            apply_orientation_by_name(context, orientation_name, sample_name=name)
             self._last_applied_orientation = orientation_name
+            # Best-effort UI sync only; not used for apply or paths
+            try:
+                context.scene.traitblender_orientation.orientation = orientation_name
+            except Exception:
+                pass
 
         # Reset and run pipeline for this image
         bpy.ops.traitblender.reset_pipeline()
@@ -188,11 +205,7 @@ class TRAITBLENDER_OT_imaging_pipeline(Operator):
             return {'CANCELLED'}
 
         morphospace_name = setup.available_morphospaces
-        allowed = set(get_orientation_names(morphospace_name)) if morphospace_name else set()
-        self._orientations = [
-            item.name for item in config.imaging.orientation_options
-            if item.enabled and item.name in allowed
-        ]
+        self._orientations = _enabled_orientation_names(context, morphospace_name)
         if not self._orientations:
             self.report({'ERROR'}, "No orientations selected for imaging. Enable at least one in the Imaging panel.")
             return {'CANCELLED'}

--- a/traitblender/ui/operators/unit_test/__init__.py
+++ b/traitblender/ui/operators/unit_test/__init__.py
@@ -1,0 +1,9 @@
+"""
+UI operators for running TraitBlender core unit tests.
+"""
+
+from .run_unit_test_op import TRAITBLENDER_OT_run_unit_test
+
+__all__ = [
+    "TRAITBLENDER_OT_run_unit_test",
+]

--- a/traitblender/ui/operators/unit_test/run_unit_test_op.py
+++ b/traitblender/ui/operators/unit_test/run_unit_test_op.py
@@ -1,0 +1,70 @@
+"""
+Operator: run a TraitBlender core unit test by name.
+"""
+
+import bpy
+from bpy.types import Operator
+from bpy.props import StringProperty
+
+from ....core.unit_test import HELP_NAME, TESTS, run_test
+
+
+class TRAITBLENDER_OT_run_unit_test(Operator):
+    """Run a registered TraitBlender unit test and report mismatches"""
+
+    bl_idname = "traitblender.run_unit_test"
+    bl_label = "Run Unit Test"
+    bl_description = (
+        "Run a TraitBlender unit test by name "
+        f'(test_name="{HELP_NAME}" lists all tests)'
+    )
+    bl_options = {'REGISTER'}
+
+    test_name: StringProperty(
+        name="Test Name",
+        description=f'Key from core.unit_test.TESTS, or "{HELP_NAME}" to list tests',
+        default=HELP_NAME,
+    )
+
+    def execute(self, context):
+        name = (self.test_name or "").strip()
+        if not name:
+            self.report({'ERROR'}, "No test_name provided")
+            return {'CANCELLED'}
+
+        try:
+            result = run_test(name, context)
+        except KeyError as e:
+            known = ", ".join(TESTS.keys()) or "(none)"
+            self.report({'ERROR'}, f"{e} Known tests: {known}")
+            return {'CANCELLED'}
+        except Exception as e:
+            self.report({'ERROR'}, f"Unit test '{name}' crashed: {e}")
+            print(f"TraitBlender: unit test '{name}' crashed: {e}")
+            return {'CANCELLED'}
+
+        message = result.get("message") or ""
+        print(message)
+
+        if result.get("help"):
+            self.report({'INFO'}, f"Listed {len(TESTS)} unit test(s) (see console)")
+            return {'FINISHED'}
+
+        passed = bool(result.get("passed"))
+        mismatches = result.get("mismatches") or []
+        print(f"TraitBlender unit test [{name}]: {'PASS' if passed else 'FAIL'}")
+        if mismatches:
+            for m in mismatches:
+                print(
+                    f"  mismatch {m.get('path')}: "
+                    f"expected={m.get('expected')!r} actual={m.get('actual')!r} "
+                    f"({m.get('reason')})"
+                )
+
+        short = message.splitlines()[0] if message else name
+        if passed:
+            self.report({'INFO'}, f"PASS {name}: {short}")
+            return {'FINISHED'}
+
+        self.report({'WARNING'}, f"FAIL {name}: {short}")
+        return {'FINISHED'}

--- a/traitblender/ui/panels/main_panel.py
+++ b/traitblender/ui/panels/main_panel.py
@@ -8,7 +8,7 @@ _pending_orientation_sync = None  # (scene_name, [orientation_names]) or None
 
 
 def _sync_imaging_orientations_timer():
-    """One-shot timer: add missing orientation_options for the pending scene."""
+    """One-shot timer: sync orientation_options to current built-in + custom names."""
     global _pending_orientation_sync
     if not _pending_orientation_sync:
         return None
@@ -21,6 +21,11 @@ def _sync_imaging_orientations_timer():
     if not hasattr(config, "imaging"):
         return None
     items = config.imaging.orientation_options
+    name_set = set(orientation_names)
+    # Remove orphaned entries (e.g. deleted custom orientations)
+    for i in range(len(items) - 1, -1, -1):
+        if items[i].name not in name_set:
+            items.remove(i)
     for name in orientation_names:
         if next((x for x in items if x.name == name), None) is None:
             item = items.add()
@@ -179,11 +184,26 @@ class TRAITBLENDER_PT_orientations_panel(Panel):
     def draw(self, context):
         layout = self.layout
         orientation_state = context.scene.traitblender_orientation
+        imaging = context.scene.traitblender_config.imaging
 
         layout.label(text="Apply orientation from the selected morphospace:")
         row = layout.row(align=True)
         row.prop(orientation_state, "orientation", text="")
         row.operator("traitblender.apply_orientation", text="Apply", icon='ORIENTATION_VIEW')
+
+        box = layout.box()
+        box.label(text="Custom orientations (radians)", icon='DRIVER_ROTATIONAL_DIFFERENCE')
+        box.label(text="Default → local Euler (X,Y,Z) → bounds center")
+
+        for i, item in enumerate(imaging.custom_orientations):
+            row = box.row(align=True)
+            row.prop(item, "name", text="")
+            row.prop(item, "rotation", text="")
+            op = row.operator("traitblender.remove_custom_orientation", text="", icon='X')
+            op.index = i
+
+        row = box.row(align=True)
+        row.operator("traitblender.add_custom_orientation", text="Add Custom", icon='ADD')
 
 class TRAITBLENDER_PT_transforms_panel(Panel):
     bl_label = "6 Transforms"
@@ -261,14 +281,20 @@ class TRAITBLENDER_PT_imaging_panel(Panel):
         row = layout.row(align=True)
         row.prop(config.imaging, "images_per_orientation", text="Images Per Orientation")
         
-        # Orientations (from current morphospace): sync via timer (cannot write in draw), then draw checkboxes
+        # Orientations (built-ins + customs): sync via timer (cannot write in draw), then draw checkboxes
         from ...core.morphospaces import get_orientation_names
         morphospace_name = setup.available_morphospaces
-        orientation_names = get_orientation_names(morphospace_name) if morphospace_name else []
+        orientation_names = (
+            get_orientation_names(morphospace_name, context) if morphospace_name else []
+        )
         if orientation_names:
             items = config.imaging.orientation_options
-            missing = [n for n in orientation_names if next((x for x in items if x.name == n), None) is None]
-            if missing:
+            current = [x.name for x in items]
+            needs_sync = (
+                any(n not in current for n in orientation_names)
+                or any(n not in orientation_names for n in current)
+            )
+            if needs_sync:
                 global _pending_orientation_sync
                 if _pending_orientation_sync is None:
                     _pending_orientation_sync = (context.scene.name, list(orientation_names))

--- a/traitblender/ui/panels/main_panel.py
+++ b/traitblender/ui/panels/main_panel.py
@@ -292,6 +292,10 @@ class TRAITBLENDER_PT_meshes_panel(Panel):
         row = box.row(align=True)
         row.prop(config.meshes, "save_meshes", text="Save meshes in imaging pipeline")
 
+        if config.meshes.save_meshes:
+            row = box.row(align=True)
+            row.prop(config.meshes, "orient_before_export", text="Orient before export")
+
         row = box.row(align=True)
         row.operator("traitblender.export_mesh", text="Export Mesh")
 

--- a/traitblender/ui/panels/main_panel.py
+++ b/traitblender/ui/panels/main_panel.py
@@ -63,13 +63,46 @@ class TRAITBLENDER_PT_main_panel(Panel):
             self._draw_section_content(box, section_obj)
 
     def _draw_section_content(self, layout, section_obj):
-        # Bind Render to the real scene settings so the UI cannot drift from Blender.
+        # Bind Render to live scene settings; show engine-specific options only.
         if section_obj.__class__.__name__ == "RenderConfig":
             scene = bpy.context.scene
             layout.prop(scene.render, "engine", text="Engine")
-            eevee = getattr(scene, "eevee", None)
-            if eevee is not None and hasattr(eevee, "use_raytracing"):
-                layout.prop(eevee, "use_raytracing", text="Use Raytracing")
+            eng = scene.render.engine or ""
+            if eng == "CYCLES":
+                cycles = getattr(scene, "cycles", None)
+                if cycles is not None:
+                    box = layout.box()
+                    box.label(text="Cycles · Render", icon='RENDER_STILL')
+                    row = box.row(align=True)
+                    row.prop(cycles, "use_adaptive_sampling", text="Noise Threshold")
+                    sub = row.row(align=True)
+                    sub.active = bool(cycles.use_adaptive_sampling)
+                    sub.prop(cycles, "adaptive_threshold", text="")
+                    box.prop(cycles, "samples", text="Max Samples")
+                    box.prop(cycles, "adaptive_min_samples", text="Min Samples")
+                    box.prop(cycles, "time_limit", text="Time Limit")
+                    if hasattr(cycles, "use_denoising"):
+                        box.prop(cycles, "use_denoising", text="Denoise")
+
+                    box = layout.box()
+                    box.label(text="Cycles · Viewport", icon='VIEW3D')
+                    row = box.row(align=True)
+                    row.prop(cycles, "use_preview_adaptive_sampling", text="Noise Threshold")
+                    sub = row.row(align=True)
+                    sub.active = bool(cycles.use_preview_adaptive_sampling)
+                    sub.prop(cycles, "preview_adaptive_threshold", text="")
+                    box.prop(cycles, "preview_samples", text="Max Samples")
+                    box.prop(cycles, "preview_adaptive_min_samples", text="Min Samples")
+                    if hasattr(cycles, "use_preview_denoising"):
+                        box.prop(cycles, "use_preview_denoising", text="Denoise")
+            elif "EEVEE" in eng.upper():
+                eevee = getattr(scene, "eevee", None)
+                if eevee is not None:
+                    layout.label(text="Eevee Sampling", icon='RENDER_STILL')
+                    if hasattr(eevee, "use_raytracing"):
+                        layout.prop(eevee, "use_raytracing", text="Use Raytracing")
+                    if hasattr(eevee, "taa_render_samples"):
+                        layout.prop(eevee, "taa_render_samples", text="Samples")
             return
 
         for prop_name in section_obj.__class__.__annotations__.keys():

--- a/traitblender/ui/panels/main_panel.py
+++ b/traitblender/ui/panels/main_panel.py
@@ -12,25 +12,17 @@ def _sync_imaging_orientations_timer():
     global _pending_orientation_sync
     if not _pending_orientation_sync:
         return None
-    scene_name, orientation_names = _pending_orientation_sync
+    scene_name, _orientation_names = _pending_orientation_sync
     _pending_orientation_sync = None
     scene = bpy.data.scenes.get(scene_name)
     if not scene or not hasattr(scene, "traitblender_config"):
         return None
-    config = scene.traitblender_config
-    if not hasattr(config, "imaging"):
-        return None
-    items = config.imaging.orientation_options
-    name_set = set(orientation_names)
-    # Remove orphaned entries (e.g. deleted custom orientations)
-    for i in range(len(items) - 1, -1, -1):
-        if items[i].name not in name_set:
-            items.remove(i)
-    for name in orientation_names:
-        if next((x for x in items if x.name == name), None) is None:
-            item = items.add()
-            item.name = name
-            item.enabled = True
+    imaging = scene.traitblender_config.imaging
+    try:
+        # Preserve current enabled flags; only add/remove to match live names.
+        imaging.sync_orientation_options(bpy.context, enabled_names=None)
+    except Exception as e:
+        print(f"TraitBlender: Imaging orientation sync failed: {e}")
     return None  # one-shot
 
 class TRAITBLENDER_PT_main_panel(Panel):
@@ -71,6 +63,15 @@ class TRAITBLENDER_PT_main_panel(Panel):
             self._draw_section_content(box, section_obj)
 
     def _draw_section_content(self, layout, section_obj):
+        # Bind Render to the real scene settings so the UI cannot drift from Blender.
+        if section_obj.__class__.__name__ == "RenderConfig":
+            scene = bpy.context.scene
+            layout.prop(scene.render, "engine", text="Engine")
+            eevee = getattr(scene, "eevee", None)
+            if eevee is not None and hasattr(eevee, "use_raytracing"):
+                layout.prop(eevee, "use_raytracing", text="Use Raytracing")
+            return
+
         for prop_name in section_obj.__class__.__annotations__.keys():
             if prop_name == "show":
                 continue
@@ -99,7 +100,7 @@ class TRAITBLENDER_PT_config_panel(Panel):
         config_sections = config.get_config_sections()
         if config_sections:
             for section_name, section_obj in config_sections.items():
-                if section_name in ["transforms", "sample", "morphospace"]:
+                if section_name in ["transforms", "sample", "morphospace", "imaging"]:
                     continue
                 self._draw_config_section(layout, section_name, section_obj)
         else:

--- a/traitblender/ui/properties/orientation_properties.py
+++ b/traitblender/ui/properties/orientation_properties.py
@@ -26,7 +26,7 @@ class TRAITBLENDER_PG_orientation(bpy.types.PropertyGroup):
         try:
             setup = context.scene.traitblender_setup
             morphospace_name = setup.available_morphospaces
-            orientations = get_orientations_for_morphospace(morphospace_name)
+            orientations = get_orientations_for_morphospace(morphospace_name, context=context)
             for name, func in orientations.items():
                 if callable(func):
                     items.append((name, name, f"Apply {name} orientation"))


### PR DESCRIPTION
Version 2.4.0 of TraitBlender. New, more flexible orienation framework for the ATLAS morphospace, some simple unit testing functionality to ensure the config gets imported properly, new VTK version that prevents TraitBlender from sometimes crashing on HPCs, and some bug fixes related to the config not being set correctly when imported. 

The release is dated for tomorrow, 7/29/2026, in the docs.